### PR TITLE
v4.1.0: Remove destination shape properties from navigation theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 ## 4.1.0
 
 * **[BREAKING] `destinationFillShape` and `destinationHoverShape` removed**
-  * `destinationFillShape` and `destinationHoverShape` were removed from
-    `AdaptiveScaffoldNavigationThemeData`.
-  * The functionality was merged and now available via the `appBarTheme.shape`
-    property.
-  * For migrating existing code, remove `destinationFillShape` and
-    `destinationHoverShape` from `AdaptiveScaffoldNavigationThemeData` and
-    replace them with `appBarTheme.shape` in `AppBarTheme`.
+  * `destinationFillShape` and `destinationHoverShape` were removed from:
+    * `AdaptiveScaffoldNavigationThemeData`
+    * `AdaptiveScaffold` (navigation helpers / navigationTheme)
+    * `CustomNavigationBar`
+    * `CustomNavigationRail`
+    * `RailDestination`
+  * The functionality is now consolidated into `ThemeData.appBarTheme.shape`.
+  * Migration: remove the old parameters and set `appBarTheme.shape` via
+    `AppBarTheme`.
 
 Before:
 ```dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 4.1.0
+
+* **[BREAKING] `destinationFillShape` and `destinationHoverShape` removed**
+  * `destinationFillShape` and `destinationHoverShape` were removed from
+    `AdaptiveScaffoldNavigationThemeData`.
+  * The functionality was merged and now available via the `appBarTheme.shape`
+    property.
+  * For migrating existing code, remove `destinationFillShape` and
+    `destinationHoverShape` from `AdaptiveScaffoldNavigationThemeData` and
+    replace them with `appBarTheme.shape` in `AppBarTheme`.
+
+Before:
+```dart
+navigationTheme: const AdaptiveScaffoldNavigationThemeData(
+  destinationFillShape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(4)),
+  ),
+  destinationHoverShape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(4)),
+  ),
+),
+```
+
+After:
+```dart
+appBarTheme: const AppBarTheme(
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(4)),
+  ),
+),
+```
+
 ## 4.0.2
 
 * **[FEAT] Destination hover shape is now configurable independently**

--- a/README.md
+++ b/README.md
@@ -35,10 +35,8 @@ several places:
   - Extended layout controls (`leadingAtTop`, `trailingAtBottom`, `scrollable`,
     `mainAxisAlignment`).
   - Configurable rail destination fill/highlight via
-    `destinationFillRegion`, `destinationHoverRegion`,
-    `destinationFillShape`, and `destinationHoverShape`.
-  - `AdaptiveScaffold` exposes the same fill options through
-    `navigationTheme: AdaptiveScaffoldNavigationThemeData(...)`.
+    `destinationFillRegion`, `destinationHoverRegion`, and
+    `ThemeData.appBarTheme.shape`.
 - Theme extensions:
   - `CustomNavigationBarThemeData`: `margin`, `padding`,
     `tooltipVerticalOffset`.
@@ -301,6 +299,8 @@ CustomNavigationDestination(
 By default, `CustomNavigationRail` follows Flutter-style selection rendering,
 where the indicator sits behind the icon area.
 
+Shape is resolved from appBar theme shape (`ThemeData.appBarTheme.shape`).
+
 When you want custom destination fill/highlight scopes, choose a
 `destinationFillRegion`:
 
@@ -310,15 +310,12 @@ When you want custom destination fill/highlight scopes, choose a
 - `label`
 - `full`
 
-Example using full-widget fill plus a custom shape:
+Example using full-widget fill:
 
 ```dart
 CustomNavigationRail(
   selectedIndex: selectedIndex,
   destinationFillRegion: NavigationDestinationRegion.full,
-  destinationFillShape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(12),
-  ),
   destinations: destinations,
 )
 ```
@@ -332,9 +329,6 @@ AdaptiveScaffold.standardNavigationRail(
   selectedIndex: selectedIndex,
   destinations: railDestinations,
   destinationFillRegion: NavigationDestinationRegion.full,
-  destinationFillShape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(12),
-  ),
 )
 ```
 
@@ -346,7 +340,6 @@ AdaptiveScaffold(
   destinations: destinations,
   navigationTheme: const AdaptiveScaffoldNavigationThemeData(
     destinationFillRegion: NavigationDestinationRegion.label,
-    destinationFillShape: StadiumBorder(),
   ),
   body: (BuildContext context) => const Placeholder(),
 )
@@ -354,8 +347,6 @@ AdaptiveScaffold(
 
 To control hover/pressed interaction region independently, use
 `destinationHoverRegion` (defaults to `destinationFillRegion` when omitted).
-To control hover/pressed interaction shape independently, use
-`destinationHoverShape` (defaults to `destinationFillShape` when omitted):
 
 ```dart
 AdaptiveScaffold(
@@ -363,10 +354,6 @@ AdaptiveScaffold(
   navigationTheme: const AdaptiveScaffoldNavigationThemeData(
     destinationFillRegion: NavigationDestinationRegion.icon,
     destinationHoverRegion: NavigationDestinationRegion.full,
-    destinationFillShape: StadiumBorder(),
-    destinationHoverShape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(12),
-    ),
   ),
   body: (BuildContext context) => const Placeholder(),
 )

--- a/example/lib/adaptive_scaffold_demo.dart
+++ b/example/lib/adaptive_scaffold_demo.dart
@@ -106,7 +106,6 @@ class _MyHomePageState extends State<MyHomePage> {
         transitionCurve: Curves.easeOutCubic,
         transitionDuration: Duration(milliseconds: 220),
         destinationFillRegion: NavigationDestinationRegion.content,
-        destinationFillShape: StadiumBorder(),
       ),
       // An option to override the default breakpoints used for small, medium,
       // mediumLarge, large, and extraLarge.

--- a/lib/src/adaptive_scaffold.dart
+++ b/lib/src/adaptive_scaffold.dart
@@ -99,11 +99,15 @@ class AdaptiveScaffoldNavigationThemeData {
   ///
   /// When null, uses Flutter's default indicator path.
   /// Passing [NavigationDestinationRegion.icon] behaves the same as null.
+  ///
+  /// To control fill shape, use `ThemeData.appBarTheme.shape`.
   final NavigationDestinationRegion? destinationFillRegion;
 
   /// Controls where destination hover/ink effects are painted.
   ///
   /// When null, this follows [destinationFillRegion].
+  ///
+  /// To control hover shape, use `ThemeData.appBarTheme.shape`.
   final NavigationDestinationRegion? destinationHoverRegion;
 }
 

--- a/lib/src/adaptive_scaffold.dart
+++ b/lib/src/adaptive_scaffold.dart
@@ -59,8 +59,6 @@ class AdaptiveScaffoldNavigationThemeData {
     this.transitionDuration,
     this.destinationFillRegion,
     this.destinationHoverRegion,
-    this.destinationFillShape,
-    this.destinationHoverShape,
   });
 
   /// Optional label behavior for compact rail and small navigation bar.
@@ -107,20 +105,6 @@ class AdaptiveScaffoldNavigationThemeData {
   ///
   /// When null, this follows [destinationFillRegion].
   final NavigationDestinationRegion? destinationHoverRegion;
-
-  /// Optional shape for destination fill/highlight.
-  ///
-  /// If null, the resolved navigation rail indicator shape is used.
-  final ShapeBorder? destinationFillShape;
-
-  /// Optional shape for hover/ink interaction.
-  ///
-  /// Note: this is only applied when [ThemeData.useMaterial3] is true. In
-  /// Material 2, hover/ink interaction continues using the default border
-  /// radius behavior.
-  ///
-  /// If null, falls back to [destinationFillShape].
-  final ShapeBorder? destinationHoverShape;
 }
 
 /// Implements the basic visual layout structure for
@@ -466,8 +450,6 @@ class AdaptiveScaffold extends StatefulWidget {
     Duration? iconTransitionDuration,
     NavigationDestinationRegion? destinationFillRegion,
     NavigationDestinationRegion? destinationHoverRegion,
-    ShapeBorder? destinationFillShape,
-    ShapeBorder? destinationHoverShape,
   }) {
     if (extended && width == 72) {
       width = 192;
@@ -526,8 +508,6 @@ class AdaptiveScaffold extends StatefulWidget {
                             iconTransitionDuration: iconTransitionDuration,
                             destinationFillRegion: destinationFillRegion,
                             destinationHoverRegion: destinationHoverRegion,
-                            destinationFillShape: destinationFillShape,
-                            destinationHoverShape: destinationHoverShape,
                           ),
                         ),
                       ),
@@ -554,8 +534,6 @@ class AdaptiveScaffold extends StatefulWidget {
         NavigationDestinationAnimation.none,
     NavigationDestinationRegion? destinationFillRegion,
     NavigationDestinationRegion? destinationHoverRegion,
-    ShapeBorder? destinationFillShape,
-    ShapeBorder? destinationHoverShape,
   }) {
     return Builder(
       builder: (BuildContext context) {
@@ -597,8 +575,6 @@ class AdaptiveScaffold extends StatefulWidget {
               labelBehavior: _labelBehaviorFromType(labelBehavior),
               destinationFillRegion: destinationFillRegion,
               destinationHoverRegion: destinationHoverRegion,
-              destinationFillShape: destinationFillShape,
-              destinationHoverShape: destinationHoverShape,
             ),
           ),
         );
@@ -835,10 +811,6 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                   effectiveNavigationTheme.destinationFillRegion,
               destinationHoverRegion:
                   effectiveNavigationTheme.destinationHoverRegion,
-              destinationFillShape:
-                  effectiveNavigationTheme.destinationFillShape,
-              destinationHoverShape:
-                  effectiveNavigationTheme.destinationHoverShape,
             ),
           ),
           widget.mediumLargeBreakpoint: SlotLayout.from(
@@ -864,10 +836,6 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                   effectiveNavigationTheme.destinationFillRegion,
               destinationHoverRegion:
                   effectiveNavigationTheme.destinationHoverRegion,
-              destinationFillShape:
-                  effectiveNavigationTheme.destinationFillShape,
-              destinationHoverShape:
-                  effectiveNavigationTheme.destinationHoverShape,
             ),
           ),
           widget.largeBreakpoint: SlotLayout.from(
@@ -897,10 +865,6 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                   effectiveNavigationTheme.destinationFillRegion,
               destinationHoverRegion:
                   effectiveNavigationTheme.destinationHoverRegion,
-              destinationFillShape:
-                  effectiveNavigationTheme.destinationFillShape,
-              destinationHoverShape:
-                  effectiveNavigationTheme.destinationHoverShape,
             ),
           ),
           widget.extraLargeBreakpoint: SlotLayout.from(
@@ -930,10 +894,6 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                   effectiveNavigationTheme.destinationFillRegion,
               destinationHoverRegion:
                   effectiveNavigationTheme.destinationHoverRegion,
-              destinationFillShape:
-                  effectiveNavigationTheme.destinationFillShape,
-              destinationHoverShape:
-                  effectiveNavigationTheme.destinationHoverShape,
             ),
           ),
         },
@@ -955,10 +915,6 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                         effectiveNavigationTheme.destinationFillRegion,
                     destinationHoverRegion:
                         effectiveNavigationTheme.destinationHoverRegion,
-                    destinationFillShape:
-                        effectiveNavigationTheme.destinationFillShape,
-                    destinationHoverShape:
-                        effectiveNavigationTheme.destinationHoverShape,
                   ),
                 ),
               },

--- a/lib/src/custom_navigation_bar.dart
+++ b/lib/src/custom_navigation_bar.dart
@@ -38,7 +38,7 @@ const double _horizontalDestinationPadding = 8.0;
 /// [DefaultTextStyle]s or [IconTheme]s but rather controlled by parameters or
 /// the [NavigationBarThemeData].
 ///
-/// The shape of the navigation bar indicators are controlled by
+/// The shape of the navigation bar indicators is controlled by
 /// [ThemeData.appBarTheme.shape].
 ///
 /// This widget holds a collection of destinations (usually

--- a/lib/src/custom_navigation_bar.dart
+++ b/lib/src/custom_navigation_bar.dart
@@ -38,6 +38,9 @@ const double _horizontalDestinationPadding = 8.0;
 /// [DefaultTextStyle]s or [IconTheme]s but rather controlled by parameters or
 /// the [NavigationBarThemeData].
 ///
+/// The shape of the navigation bar indicators are controlled by
+/// [ThemeData.appBarTheme.shape].
+///
 /// This widget holds a collection of destinations (usually
 /// [CustomNavigationDestination]s).
 ///

--- a/lib/src/custom_navigation_bar.dart
+++ b/lib/src/custom_navigation_bar.dart
@@ -105,8 +105,6 @@ class CustomNavigationBar extends StatelessWidget {
     this.labelPadding,
     this.destinationFillRegion,
     this.destinationHoverRegion,
-    this.destinationFillShape,
-    this.destinationHoverShape,
     this.maintainBottomViewPadding = false,
   })  : assert(destinations.length >= 2),
         assert(0 <= selectedIndex && selectedIndex < destinations.length);
@@ -246,20 +244,6 @@ class CustomNavigationBar extends StatelessWidget {
   /// When null, this follows [destinationFillRegion].
   final NavigationDestinationRegion? destinationHoverRegion;
 
-  /// Optional shape for destination fill/highlight.
-  ///
-  /// If null, the resolved navigation bar indicator shape is used.
-  final ShapeBorder? destinationFillShape;
-
-  /// Optional shape used for hover/ink interaction.
-  ///
-  /// Note: this is only applied when [ThemeData.useMaterial3] is true. In
-  /// Material 2, hover/ink interaction continues using the default border
-  /// radius behavior.
-  ///
-  /// If null, falls back to [destinationFillShape].
-  final ShapeBorder? destinationHoverShape;
-
   /// Specifies whether [SafeArea] should maintain bottom view padding.
   final bool maintainBottomViewPadding;
 
@@ -333,8 +317,6 @@ class CustomNavigationBar extends StatelessWidget {
                               labelPadding: labelPadding,
                               destinationFillRegion: destinationFillRegion,
                               destinationHoverRegion: destinationHoverRegion,
-                              destinationFillShape: destinationFillShape,
-                              destinationHoverShape: destinationHoverShape,
                               onTap: _handleTap(i),
                               child: destinations[i],
                             );
@@ -819,9 +801,10 @@ class _NavigationDestinationBuilderState
         widget.iconIndicatorShape == null &&
         widget.labelIndicatorShape == null;
     final ShapeBorder effectiveFillShape =
-        info.destinationFillShape ?? widget.shape ?? const StadiumBorder();
-    final ShapeBorder effectiveHoverShape =
-        info.destinationHoverShape ?? effectiveFillShape;
+        Theme.of(context).appBarTheme.shape ??
+            widget.shape ??
+            const StadiumBorder();
+    final ShapeBorder effectiveHoverShape = effectiveFillShape;
     final TextDirection textDirection = Directionality.of(context);
     final EdgeInsets fillPadding = widget.padding.resolve(textDirection);
     final bool hasVisibleText = switch (info.labelBehavior) {
@@ -1005,8 +988,6 @@ class _NavigationDestinationInfo extends InheritedWidget {
     required this.labelPadding,
     required this.destinationFillRegion,
     required this.destinationHoverRegion,
-    required this.destinationFillShape,
-    required this.destinationHoverShape,
     required this.onTap,
     required super.child,
   });
@@ -1091,12 +1072,6 @@ class _NavigationDestinationInfo extends InheritedWidget {
   /// Where destination hover/ink interaction effects are painted.
   final NavigationDestinationRegion? destinationHoverRegion;
 
-  /// Optional override shape for destination fill/highlight.
-  final ShapeBorder? destinationFillShape;
-
-  /// Optional override shape for hover/ink interaction.
-  final ShapeBorder? destinationHoverShape;
-
   /// The callback that should be called when this destination is tapped.
   ///
   /// This is computed by calling [CustomNavigationBar.onDestinationSelected]
@@ -1131,8 +1106,6 @@ class _NavigationDestinationInfo extends InheritedWidget {
         labelPadding != oldWidget.labelPadding ||
         destinationFillRegion != oldWidget.destinationFillRegion ||
         destinationHoverRegion != oldWidget.destinationHoverRegion ||
-        destinationFillShape != oldWidget.destinationFillShape ||
-        destinationHoverShape != oldWidget.destinationHoverShape ||
         onTap != oldWidget.onTap;
   }
 }

--- a/lib/src/custom_navigation_rail.dart
+++ b/lib/src/custom_navigation_rail.dart
@@ -49,7 +49,8 @@ class CustomNavigationRailDestination extends NavigationRailDestination {
 /// The appearance of all of the [CustomNavigationRail]s within an app can be
 /// specified with [NavigationRailTheme]. The default values for null theme
 /// properties are based on the [Theme]'s [ThemeData.textTheme],
-/// [ThemeData.iconTheme], and [ThemeData.colorScheme].
+/// [ThemeData.iconTheme], [ThemeData.colorScheme], and
+/// [ThemeData.appBarTheme.shape].
 ///
 /// Adaptive layouts can build different instances of the [Scaffold] in order to
 /// have a navigation rail for more horizontal layouts and a bottom navigation

--- a/lib/src/custom_navigation_rail.dart
+++ b/lib/src/custom_navigation_rail.dart
@@ -129,8 +129,6 @@ class CustomNavigationRail extends StatefulWidget {
     this.indicatorShape,
     this.destinationFillRegion,
     this.destinationHoverRegion,
-    this.destinationFillShape,
-    this.destinationHoverShape,
     this.leadingAtTop = true,
     this.trailingAtBottom = false,
     this.scrollable = false,
@@ -364,23 +362,6 @@ class CustomNavigationRail extends StatefulWidget {
   ///
   /// When null, this follows [destinationFillRegion].
   final NavigationDestinationRegion? destinationHoverRegion;
-
-  /// Optional shape used for destination fill/highlight when
-  /// [destinationFillRegion] is configured.
-  ///
-  /// If null, [indicatorShape] / theme indicator shape is used, then
-  /// [StadiumBorder].
-  final ShapeBorder? destinationFillShape;
-
-  /// Optional shape used for hover/ink interaction when
-  /// [destinationHoverRegion] is configured.
-  ///
-  /// Note: this is only applied when [ThemeData.useMaterial3] is true. In
-  /// Material 2, hover/ink interaction continues using the default border
-  /// radius behavior.
-  ///
-  /// If null, falls back to [destinationFillShape].
-  final ShapeBorder? destinationHoverShape;
 
   /// Icon transition preset for destination icon swaps.
   ///
@@ -638,8 +619,6 @@ class _CustomNavigationRailState extends State<CustomNavigationRail>
                 indicatorShape: indicatorShape,
                 destinationFillRegion: widget.destinationFillRegion,
                 destinationHoverRegion: widget.destinationHoverRegion,
-                destinationFillShape: widget.destinationFillShape,
-                destinationHoverShape: widget.destinationHoverShape,
                 onTap: () {
                   if (widget.onDestinationSelected != null) {
                     widget.onDestinationSelected!(i);

--- a/lib/src/rail_destination.dart
+++ b/lib/src/rail_destination.dart
@@ -23,8 +23,6 @@ class RailDestination extends StatefulWidget {
     this.indicatorShape,
     this.destinationFillRegion,
     this.destinationHoverRegion,
-    this.destinationFillShape,
-    this.destinationHoverShape,
     this.disabled = false,
     this.extended = true,
     this.padding,
@@ -54,8 +52,6 @@ class RailDestination extends StatefulWidget {
   final ShapeBorder? indicatorShape;
   final NavigationDestinationRegion? destinationFillRegion;
   final NavigationDestinationRegion? destinationHoverRegion;
-  final ShapeBorder? destinationFillShape;
-  final ShapeBorder? destinationHoverShape;
   final bool disabled;
   final bool extended;
   final EdgeInsetsGeometry? padding;
@@ -254,7 +250,7 @@ class _RailDestinationState extends State<RailDestination>
     final bool shouldShowIconIndicator =
         (widget.useIndicator ?? false) && isDefaultFillPath;
     final ShapeBorder effectiveIconIndicatorShape =
-        widget.destinationFillShape ??
+        Theme.of(context).appBarTheme.shape ??
             indicatorShape ??
             (destinationFillRegion == NavigationDestinationRegion.full
                 ? const RoundedRectangleBorder()
@@ -652,9 +648,10 @@ class _RailDestinationState extends State<RailDestination>
             ? const RoundedRectangleBorder()
             : const StadiumBorder();
     final ShapeBorder effectiveFillShape =
-        widget.destinationFillShape ?? indicatorShape ?? defaultFillShape;
-    final ShapeBorder effectiveInkShape =
-        widget.destinationHoverShape ?? effectiveFillShape;
+        Theme.of(context).appBarTheme.shape ??
+            indicatorShape ??
+            defaultFillShape;
+    final ShapeBorder effectiveInkShape = effectiveFillShape;
     final bool hasVisibleText = !collapsed
         ? switch (labelType) {
             NavigationRailLabelType.none => false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: custom_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 4.0.2
+version: 4.1.0
 issue_tracker: https://github.com/hanskokx/custom_adaptive_scaffold/issues
 repository: https://github.com/hanskokx/custom_adaptive_scaffold
 

--- a/test/custom_navigation_custom_features_test.dart
+++ b/test/custom_navigation_custom_features_test.dart
@@ -739,7 +739,7 @@ void main() {
     expect(rect.height, greaterThanOrEqualTo(32));
   });
 
-  testWidgets("destinationFillShape is applied to interaction shape", (
+  testWidgets("ThemeData.appBarTheme.shape is applied to interaction shape", (
     WidgetTester tester,
   ) async {
     final ShapeBorder fillShape = RoundedRectangleBorder(

--- a/test/custom_navigation_custom_features_test.dart
+++ b/test/custom_navigation_custom_features_test.dart
@@ -748,12 +748,14 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(useMaterial3: true),
+        theme: ThemeData(
+          useMaterial3: true,
+          appBarTheme: AppBarTheme(shape: fillShape),
+        ),
         home: Scaffold(
           body: CustomNavigationRail(
             selectedIndex: 0,
             destinationFillRegion: NavigationDestinationRegion.full,
-            destinationFillShape: fillShape,
             destinations: const <NavigationRailDestination>[
               NavigationRailDestination(
                 icon: Icon(Icons.home_outlined),


### PR DESCRIPTION
Removed `destinationFillShape` and `destinationHoverShape` from `AdaptiveScaffoldNavigationThemeData`, `AdaptiveScaffold`, `CustomNavigationBar`, and `CustomNavigationRail`. This functionality is now consolidated into `AppBarTheme.shape`.