### PR TITLE
Enhance NavigationBar and NavigationRail for large icon support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
+## 5.1.0
+
+- **[FEAT]** Improved large icon support for `NavigationBar` and `NavigationRail`.
+  - Indicator and icon-slot sizing now scale correctly for explicit large icon theme overrides.
+  - Rail destination spacing and indicator alignment were refined for large icon use cases.
+  - The maximum allowed sizes are `72` for the `NavigationRail` and `60` for the `NavigationBar`.
+- **[FEAT]** Added `NavigationRailThemeData.iconTheme` support to the package-owned rail theme data.
+  - This brings the `NavigationRailThemeData.iconTheme` into parity with the pre-existing `NavigationBarThemeData.iconTheme`
+- **[IMPROVEMENT]** `NavigationBarTheme.maybeOf(context)` now resolves explicit theme intent more accurately.
+- **[IMPROVEMENT]** `AdaptiveScaffold.standardBottomNavigationBar` now better respects existing themed icon sizes.
+  - `iconSize` is now optional and falls back to themed icon size before defaulting to `24.0` (the Material 3 default).
+  - Legacy `iconSize`, `padding`, and `margin` overrides are marked deprecated in favor of theme-driven configuration.
+    - This is in preparation for the upcoming 6.0.0 release, wherein Material 2 support is planned to be removed.
+
 ## 5.0.1
 
-- No package changes
+- No package cha
 - Documentation has been updated
 
 ## 5.0.0

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ import 'package:custom_adaptive_scaffold/custom_adaptive_scaffold.dart';
 ## How Is This Different From Flutter?
 
 This package keeps Flutter's default look and feel but exposes opt-in customization points that the framework does not provide.
+When package-specific extension properties are not set, bar/rail behavior follows Flutter framework-mirror defaults.
 
 ### Extended theme data
 
@@ -119,7 +120,12 @@ everywhere Flutter's types are expected. They add:
 | `tooltipTriggerWhenLabelVisible` | ✓              | Override trigger when label is shown          |
 | `tooltipTriggerWhenLabelHidden`  | ✓              | Override trigger when label is hidden         |
 
-`NavigationRailThemeData` additionally provides `showLabelsWhenCollapsed` (show labels while the rail is collapsed and `labelType` is `none`).
+`NavigationRailThemeData` additionally provides:
+
+- `showLabelsWhenCollapsed` (show labels while the rail is collapsed and `labelType` is `none`)
+- `iconTheme` (state-aware icon theming for rail destinations, including explicit large icon sizing)
+  - The maximum supported icon size for the `NavigationRail` is `72.0`.
+  - The maximum supported icon size for the `NavigationBar` is `60.0`.
 
 ### Richer `NavigationDestination` base class
 

--- a/lib/navigation_bar_theme.dart
+++ b/lib/navigation_bar_theme.dart
@@ -572,10 +572,10 @@ class NavigationBarTheme extends InheritedTheme
       return navigationBarTheme.data;
     }
 
-    // The user is using Flutter's Material NavigationBarThemeData, so we
-    // convert it to our own NavigationBarThemeData.
+    // Read the raw ThemeData field so we only consider explicitly provided
+    // values, not merged defaults from Flutter's NavigationBarTheme.of.
     final m.NavigationBarThemeData materialNavigationBarTheme =
-        m.NavigationBarTheme.of(context);
+        Theme.of(context).navigationBarTheme;
 
     if (materialNavigationBarTheme is NavigationBarThemeData) {
       return materialNavigationBarTheme;
@@ -606,6 +606,7 @@ class NavigationBarTheme extends InheritedTheme
     final NavigationBarThemeData defaults = navigationBarDefaultsFor(context);
 
     final NavigationBarThemeData? explicitTheme = maybeOf(context);
+
     if (explicitTheme != null) {
       return defaults.copyWith(
         height: explicitTheme.height,

--- a/lib/navigation_rail_theme.dart
+++ b/lib/navigation_rail_theme.dart
@@ -61,6 +61,7 @@ class NavigationRailThemeData
     this.groupAlignment,
     this.indicatorColor,
     this.indicatorShape,
+    this.iconTheme,
     this.labelType,
     this.margin,
     this.minExtendedWidth,
@@ -127,6 +128,10 @@ class NavigationRailThemeData
     "Migrate to Material 3 by relying on the default M3 behavior.",
   )
   final IconThemeData? selectedIconTheme;
+
+  /// The theme to merge with the default icon theme for
+  /// [NavigationRailDestination] icons.
+  final WidgetStateProperty<IconThemeData?>? iconTheme;
 
   /// The alignment for the [NavigationRailDestination]s as they are positioned
   /// within the [NavigationRail].
@@ -253,6 +258,7 @@ class NavigationRailThemeData
     TooltipTriggerMode? tooltipTrigger,
     TooltipTriggerMode? tooltipTriggerWhenLabelVisible,
     TooltipTriggerMode? tooltipTriggerWhenLabelHidden,
+    WidgetStateProperty<IconThemeData?>? iconTheme,
   }) {
     return NavigationRailThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -284,6 +290,7 @@ class NavigationRailThemeData
           tooltipTriggerWhenLabelVisible ?? this.tooltipTriggerWhenLabelVisible,
       tooltipTriggerWhenLabelHidden:
           tooltipTriggerWhenLabelHidden ?? this.tooltipTriggerWhenLabelHidden,
+      iconTheme: iconTheme ?? this.iconTheme,
     );
   }
 
@@ -355,6 +362,12 @@ class NavigationRailThemeData
       tooltipTriggerWhenLabelHidden: t < 0.5
           ? a?.tooltipTriggerWhenLabelHidden
           : b?.tooltipTriggerWhenLabelHidden,
+      iconTheme: WidgetStateProperty.lerp<IconThemeData?>(
+        a?.iconTheme,
+        b?.iconTheme,
+        t,
+        IconThemeData.lerp,
+      ),
     );
   }
 
@@ -382,6 +395,7 @@ class NavigationRailThemeData
         tooltipTrigger,
         tooltipTriggerWhenLabelVisible,
         tooltipTriggerWhenLabelHidden,
+        iconTheme,
       ]);
 
   @override
@@ -415,7 +429,8 @@ class NavigationRailThemeData
         other.tooltipTrigger == tooltipTrigger &&
         other.tooltipTriggerWhenLabelVisible ==
             tooltipTriggerWhenLabelVisible &&
-        other.tooltipTriggerWhenLabelHidden == tooltipTriggerWhenLabelHidden;
+        other.tooltipTriggerWhenLabelHidden == tooltipTriggerWhenLabelHidden &&
+        other.iconTheme == iconTheme;
   }
 
   @override
@@ -577,6 +592,13 @@ class NavigationRailThemeData
         defaultValue: null,
       ),
     );
+    properties.add(
+      DiagnosticsProperty<WidgetStateProperty<IconThemeData?>?>(
+        "iconTheme",
+        iconTheme,
+        defaultValue: null,
+      ),
+    );
   }
 
   factory NavigationRailThemeData.fromMaterial(
@@ -607,6 +629,7 @@ class NavigationRailThemeData
       tooltipTrigger: null,
       tooltipTriggerWhenLabelVisible: null,
       tooltipTriggerWhenLabelHidden: null,
+      iconTheme: null,
     );
   }
 }
@@ -653,6 +676,7 @@ class NavigationRailTheme extends InheritedTheme
     final m.NavigationRailThemeData materialNavigationRailTheme =
         m.NavigationRailTheme.of(context);
 
+    // This is the package's custom implementation
     if (materialNavigationRailTheme is NavigationRailThemeData) {
       return materialNavigationRailTheme;
     }
@@ -710,6 +734,7 @@ class NavigationRailTheme extends InheritedTheme
             explicitTheme.tooltipTriggerWhenLabelVisible,
         tooltipTriggerWhenLabelHidden:
             explicitTheme.tooltipTriggerWhenLabelHidden,
+        iconTheme: explicitTheme.iconTheme,
       );
     }
 

--- a/lib/src/adaptive_scaffold.dart
+++ b/lib/src/adaptive_scaffold.dart
@@ -474,6 +474,7 @@ class AdaptiveScaffold extends StatefulWidget {
         final NavigationRailThemeData resolvedNavRailTheme =
             NavigationRailTheme.maybeOf(context) ??
                 const NavigationRailThemeData();
+
         return NavigationRailTheme(
           data: resolvedNavRailTheme.copyWith(
             margin: margin ?? resolvedNavRailTheme.margin,
@@ -532,11 +533,29 @@ class AdaptiveScaffold extends StatefulWidget {
   static Builder standardBottomNavigationBar({
     required List<NavigationDestination> destinations,
     int? currentIndex,
-    double iconSize = 24,
+    // TODO(v6.0.0): Remove to deprecate M2.
+    @Deprecated(
+      "Material 2 is deprecated in Flutter and will be removed in v6.0.0 of this package. "
+      "Migrate to Material 3 by relying on the default M3 behavior. "
+      "To override this property, instead use NavigationBarThemeData.iconTheme.",
+    )
+    double? iconSize,
     Duration animationDuration = const Duration(milliseconds: 180),
     ValueChanged<int>? onDestinationSelected,
     bool? scrollable,
+    // TODO(v6.0.0): Remove to deprecate M2.
+    @Deprecated(
+      "Material 2 is deprecated in Flutter and will be removed in v6.0.0 of this package. "
+      "Migrate to Material 3 by relying on the default M3 behavior. "
+      "To override this property, instead use NavigationBarThemeData.padding.",
+    )
     EdgeInsetsGeometry? padding,
+    // TODO(v6.0.0): Remove to deprecate M2.
+    @Deprecated(
+      "Material 2 is deprecated in Flutter and will be removed in v6.0.0 of this package. "
+      "Migrate to Material 3 by relying on the default M3 behavior. "
+      "To override this property, instead use NavigationBarThemeData.margin.",
+    )
     EdgeInsetsGeometry? margin,
   }) {
     return Builder(
@@ -545,13 +564,17 @@ class AdaptiveScaffold extends StatefulWidget {
             NavigationBarTheme.maybeOf(context) ??
                 const NavigationBarThemeData();
 
+        const double kDefaultIconSize = 24.0;
+
         return NavigationBarTheme(
           data: resolvedNavBarTheme.copyWith(
             iconTheme: WidgetStateProperty.resolveWith((states) {
               final IconThemeData? existing =
                   resolvedNavBarTheme.iconTheme?.resolve(states);
               return (existing ?? const IconThemeData()).copyWith(
-                size: iconSize,
+                size: iconSize ??
+                    resolvedNavBarTheme.iconTheme?.resolve(states)?.size ??
+                    kDefaultIconSize,
               );
             }),
             padding: padding ?? resolvedNavBarTheme.padding,

--- a/lib/src/navigation_bar/destination.dart
+++ b/lib/src/navigation_bar/destination.dart
@@ -66,6 +66,8 @@ class NavigationBarDestination extends NavigationDestination {
   Widget build(BuildContext context) {
     final NavigationDestinationInfo info =
         NavigationDestinationInfo.of(context);
+    final NavigationBarThemeData? maybeExplicitTheme =
+        NavigationBarTheme.maybeOf(context);
     final NavigationBarThemeData navigationBarTheme =
         NavigationBarTheme.of(context);
     final Animation<double> animation = info.selectedAnimation;
@@ -82,6 +84,34 @@ class NavigationBarDestination extends NavigationDestination {
     final EdgeInsetsGeometry padding =
         this.padding ?? navigationBarTheme.padding ?? EdgeInsets.zero;
 
+    final DestinationBuildData data = const BarDestinationStrategy().resolve(
+      context,
+      DestinationResolveInput(
+        icon: icon, // fallback or dummy just to extract size metrics
+        label: Text(label),
+        selected: info.index == info.selectedIndex,
+        disabled: !enabled,
+        destinationAnimation: animation,
+        indicatorShape: indicatorShape,
+      ),
+    );
+
+    final bool hasExplicitPackageDestinationCustomization =
+        maybeExplicitTheme?.destinationOverlayColor != null ||
+            maybeExplicitTheme?.destinationIndicatorShape != null;
+    final bool hasExplicitIconSizeOverride =
+        info.iconTheme != null || maybeExplicitTheme?.iconTheme != null;
+    final bool useExpandedIndicatorSlot =
+        hasExplicitPackageDestinationCustomization ||
+            hasExplicitIconSizeOverride;
+
+    final double largeIconCompensation =
+        ((data.resolvedIconSize ?? 0) - _kIndicatorHeight)
+            .clamp(0.0, double.infinity);
+    final double effectiveIndicatorHeight = useExpandedIndicatorSlot
+        ? _kIndicatorHeight + largeIconCompensation
+        : _kIndicatorHeight;
+
     return Container(
       margin: margin,
       child: _NavigationBarDestinationBuilder(
@@ -95,6 +125,7 @@ class NavigationBarDestination extends NavigationDestination {
         color: indicatorColor,
         shape: indicatorShape,
         padding: padding,
+        indicatorHeight: effectiveIndicatorHeight,
         buildIcon: (BuildContext context) {
           final NavigationDestinationInfo currentInfo =
               NavigationDestinationInfo.of(context);
@@ -131,7 +162,7 @@ class NavigationBarDestination extends NavigationDestination {
                 color: indicatorColor,
                 shape: indicatorShape,
                 width: data.minWidth,
-                height: _kIndicatorHeight,
+                height: effectiveIndicatorHeight,
               ),
               Builder(
                 builder: (BuildContext context) {
@@ -147,7 +178,7 @@ class NavigationBarDestination extends NavigationDestination {
                       icon: data.themedIcon,
                       minWidth: data.minWidth,
                       material3: data.material3,
-                      height: _kIndicatorHeight,
+                      height: effectiveIndicatorHeight,
                       addSpacing: false,
                       direction: Axis.vertical,
                     ),

--- a/lib/src/navigation_bar/destination/builder.dart
+++ b/lib/src/navigation_bar/destination/builder.dart
@@ -2,23 +2,13 @@ part of "../destination.dart";
 
 /// Widget that handles the semantics and layout of a navigation bar
 /// destination.
-///
-/// Prefer [NavigationDestination] over this widget, as it is a simpler
-/// (although less customizable) way to get navigation bar destinations.
-///
-/// The icon and label of this destination are built with [buildIcon] and
-/// [buildLabel]. They should build the unselected and selected icon and label
-/// according to [NavigationDestinationInfo.selectedAnimation], where an
-/// animation value of 0 is unselected and 1 is selected.
-///
-/// See [NavigationDestination] for an example.
 class _NavigationBarDestinationBuilder extends StatefulWidget {
-  /// Builds a destination (icon + label) to use in a Material 3 [NavigationBar].
   const _NavigationBarDestinationBuilder({
     required this.buildIcon,
     required this.buildLabel,
     required this.label,
     required this.animation,
+    required this.indicatorHeight,
     super.key,
     this.color,
     this.shape,
@@ -27,47 +17,12 @@ class _NavigationBarDestinationBuilder extends StatefulWidget {
     this.padding = EdgeInsets.zero,
   });
 
-  /// Builds the icon for a destination in a [NavigationBar].
-  ///
-  /// To animate between unselected and selected, build the icon based on
-  /// [NavigationDestinationInfo.selectedAnimation]. When the animation is 0,
-  /// the destination is unselected, when the animation is 1, the destination is
-  /// selected.
-  ///
-  /// The destination is considered selected as soon as the animation is
-  /// increasing or completed, and it is considered unselected as soon as the
-  /// animation is decreasing or dismissed.
+  final double indicatorHeight;
   final WidgetBuilder buildIcon;
-
-  /// Builds the label for a destination in a [NavigationBar].
-  ///
-  /// To animate between unselected and selected, build the icon based on
-  /// [NavigationDestinationInfo.selectedAnimation]. When the animation is
-  /// 0, the destination is unselected, when the animation is 1, the destination
-  /// is selected.
-  ///
-  /// The destination is considered selected as soon as the animation is
-  /// increasing or completed, and it is considered unselected as soon as the
-  /// animation is decreasing or dismissed.
   final WidgetBuilder buildLabel;
-
-  /// The text value of what is in the label widget, this is required for
-  /// semantics so that screen readers and tooltips can read the proper label.
   final Widget label;
-
-  /// The text to display in the tooltip for this [NavigationDestination], when
-  /// the user long presses the destination.
-  ///
-  /// If [tooltip] is an empty string, no tooltip will be used.
-  ///
-  /// Defaults to null, in which case the [label] text will be used.
   final String? tooltip;
-
-  /// Indicates that this destination is unselectable.
-  ///
-  /// Defaults to false.
   final bool disabled;
-
   final Animation<double> animation;
   final Color? color;
   final ShapeBorder? shape;
@@ -82,14 +37,12 @@ class _NavigationBarDestinationBuilderState
     extends State<_NavigationBarDestinationBuilder> {
   final GlobalKey itemKey = GlobalKey();
   final GlobalKey iconKey = GlobalKey();
-
-  @override
-  void initState() {
-    super.initState();
-  }
+  late final WidgetStatesController _statesController =
+      WidgetStatesController();
 
   @override
   void dispose() {
+    _statesController.dispose();
     super.dispose();
   }
 
@@ -100,41 +53,70 @@ class _NavigationBarDestinationBuilderState
     final bool isDisabled = widget.disabled;
 
     final ThemeData theme = Theme.of(context);
-    final CustomNavigationBarThemeData? navigationBarTheme =
+    final CustomNavigationBarThemeData? maybeNavigationBarTheme =
         NavigationBarTheme.maybeOf(context);
+    final CustomNavigationBarThemeData navigationBarTheme =
+        NavigationBarTheme.of(context);
     final CustomNavigationBarThemeData defaults =
         navigationBarDefaultsFor(context);
+
+    final bool hasExplicitPackageDestinationOverlay =
+        maybeNavigationBarTheme?.destinationOverlayColor != null;
+    final bool hasExplicitPackageDestinationShape =
+        maybeNavigationBarTheme?.destinationIndicatorShape != null;
+
     final bool useEnhancedItemInk = theme.useMaterial3 &&
-        (navigationBarTheme?.destinationOverlayColor != null ||
-            navigationBarTheme?.destinationIndicatorShape != null);
+        (hasExplicitPackageDestinationOverlay ||
+            hasExplicitPackageDestinationShape);
+
     final ShapeBorder effectiveNavigationItemIndicatorShape =
-        navigationBarTheme?.destinationIndicatorShape ??
-            navigationBarTheme?.indicatorShape ??
+        navigationBarTheme.destinationIndicatorShape ??
+            navigationBarTheme.indicatorShape ??
             defaults.indicatorShape ??
             const StadiumBorder();
 
     final WidgetStateProperty<Color?>? iconOverlayColor =
-        info.overlayColor ?? navigationBarTheme?.overlayColor;
+        info.overlayColor ?? maybeNavigationBarTheme?.overlayColor;
     final WidgetStateProperty<Color?>? fullItemOverlayColor =
-        navigationBarTheme?.destinationOverlayColor ?? iconOverlayColor;
+        maybeNavigationBarTheme?.overlayColor ??
+            maybeNavigationBarTheme?.destinationOverlayColor ??
+            iconOverlayColor;
+
     final String labelText =
         widget.label is Text ? (widget.label as Text).data ?? "" : "";
     final String? tooltipMessage = widget.tooltip == null
         ? (labelText.isNotEmpty ? labelText : null)
         : (widget.tooltip!.isNotEmpty ? widget.tooltip : null);
+
     final bool isSelected = info.index == info.selectedIndex;
+
+// Retain WidgetState.selected for default Flutter behavior when custom properties aren't in use
+    _statesController.value = {
+      if (isDisabled) WidgetState.disabled,
+      if (isSelected && widget.indicatorHeight == 32.0) WidgetState.selected,
+    };
+
+    final WidgetStateProperty<Color?> effectiveFrameworkOverlayColor =
+        WidgetStateProperty.resolveWith<Color?>((Set<WidgetState> states) {
+      final Set<WidgetState> resolvedStates = {
+        ...states,
+        if (isDisabled) WidgetState.disabled,
+      };
+      return iconOverlayColor?.resolve(resolvedStates);
+    });
+
     final bool isLabelVisible = switch (info.labelBehavior) {
       NavigationDestinationLabelBehavior.alwaysShow => true,
       NavigationDestinationLabelBehavior.onlyShowSelected => isSelected,
       NavigationDestinationLabelBehavior.alwaysHide => false,
     };
     final Offset effectiveTooltipOffset =
-        navigationBarTheme?.tooltipOffset ?? const Offset(0, 42);
+        navigationBarTheme.tooltipOffset ?? const Offset(0, 42);
     final TooltipTriggerMode? effectiveTooltipTrigger = isLabelVisible
-        ? navigationBarTheme?.tooltipTriggerWhenLabelVisible ??
-            navigationBarTheme?.tooltipTrigger
-        : navigationBarTheme?.tooltipTriggerWhenLabelHidden ??
-            navigationBarTheme?.tooltipTrigger;
+        ? navigationBarTheme.tooltipTriggerWhenLabelVisible ??
+            navigationBarTheme.tooltipTrigger
+        : navigationBarTheme.tooltipTriggerWhenLabelHidden ??
+            navigationBarTheme.tooltipTrigger;
 
     return _NavigationBarDestinationSemantics(
       enabled: !isDisabled,
@@ -152,6 +134,8 @@ class _NavigationBarDestinationBuilderState
                 isSelected: isSelected,
                 iconKey: iconKey,
                 itemKey: itemKey,
+                height: widget.indicatorHeight,
+                statesController: _statesController,
                 child: _DestinationLayout(
                   buildIcon: widget.buildIcon,
                   buildLabel: widget.buildLabel,
@@ -164,10 +148,12 @@ class _NavigationBarDestinationBuilderState
             : _FrameworkIndicatorInkWell(
                 iconKey: iconKey,
                 labelBehavior: info.labelBehavior,
+                indicatorHeight: widget.indicatorHeight,
+                statesController: _statesController,
                 customBorder: info.indicatorShape ??
-                    navigationBarTheme?.indicatorShape ??
+                    navigationBarTheme.indicatorShape ??
                     defaults.indicatorShape,
-                overlayColor: iconOverlayColor,
+                overlayColor: effectiveFrameworkOverlayColor,
                 onTap: isDisabled ? null : info.onTap,
                 child: _DestinationLayout(
                   buildIcon: widget.buildIcon,
@@ -193,6 +179,8 @@ class _FullItemIndicatorInkWell extends StatelessWidget {
     required this.iconKey,
     required this.itemKey,
     required this.child,
+    required this.height,
+    required this.statesController,
   });
 
   final ShapeBorder effectiveNavigationItemIndicatorShape;
@@ -203,6 +191,8 @@ class _FullItemIndicatorInkWell extends StatelessWidget {
   final GlobalKey<State<StatefulWidget>> iconKey;
   final GlobalKey<State<StatefulWidget>> itemKey;
   final Widget child;
+  final double height;
+  final WidgetStatesController statesController;
 
   @override
   Widget build(BuildContext context) {
@@ -212,16 +202,20 @@ class _FullItemIndicatorInkWell extends StatelessWidget {
       ),
       child: Material(
         child: InkResponse(
+          statesController: statesController,
           containedInkWell: true,
           highlightShape: BoxShape.rectangle,
           overlayColor: fullItemOverlayColor,
           hoverColor: fullItemOverlayColor?.resolve({
+            if (isSelected) WidgetState.selected,
             WidgetState.hovered,
           }),
           focusColor: fullItemOverlayColor?.resolve({
+            if (isSelected) WidgetState.selected,
             WidgetState.focused,
           }),
           splashColor: fullItemOverlayColor?.resolve({
+            if (isSelected) WidgetState.selected,
             WidgetState.pressed,
           }),
           onTap: isDisabled ? null : info.onTap,
@@ -301,6 +295,8 @@ class _FrameworkIndicatorInkWell extends InkResponse {
   const _FrameworkIndicatorInkWell({
     required this.iconKey,
     required this.labelBehavior,
+    required this.indicatorHeight,
+    super.statesController,
     super.overlayColor,
     super.customBorder,
     super.onTap,
@@ -312,6 +308,7 @@ class _FrameworkIndicatorInkWell extends InkResponse {
 
   final GlobalKey iconKey;
   final NavigationDestinationLabelBehavior labelBehavior;
+  final double indicatorHeight;
 
   @override
   RectCallback? getRectCallback(RenderBox referenceBox) {
@@ -319,7 +316,22 @@ class _FrameworkIndicatorInkWell extends InkResponse {
       final RenderBox iconBox =
           iconKey.currentContext!.findRenderObject()! as RenderBox;
       final Rect iconRect = iconBox.localToGlobal(Offset.zero) & iconBox.size;
-      return referenceBox.globalToLocal(iconRect.topLeft) & iconBox.size;
+
+      // Preserve standard Flutter behavior when custom properties aren't in use
+      if (indicatorHeight == 32.0) {
+        return referenceBox.globalToLocal(iconRect.topLeft) & iconBox.size;
+      }
+
+      final Rect localIconRect =
+          referenceBox.globalToLocal(iconRect.topLeft) & iconBox.size;
+
+      const double indicatorWidth = 64.0;
+
+      return Rect.fromCenter(
+        center: localIconRect.center,
+        width: indicatorWidth,
+        height: indicatorHeight,
+      );
     };
   }
 }

--- a/lib/src/navigation_bar/destination_info.dart
+++ b/lib/src/navigation_bar/destination_info.dart
@@ -19,6 +19,7 @@ class NavigationDestinationInfo extends InheritedWidget {
     required this.overlayColor,
     required this.onTap,
     required super.child,
+    this.iconTheme,
     this.labelTextStyle,
     this.labelPadding,
     super.key,
@@ -95,6 +96,9 @@ class NavigationDestinationInfo extends InheritedWidget {
   /// The text style of the label.
   final WidgetStateProperty<TextStyle?>? labelTextStyle;
 
+  /// The icon theme of the destination.
+  final WidgetStateProperty<IconThemeData?>? iconTheme;
+
   /// The padding around the destination label.
   final EdgeInsetsGeometry? labelPadding;
 
@@ -133,6 +137,7 @@ class NavigationDestinationInfo extends InheritedWidget {
         indicatorShape != oldWidget.indicatorShape ||
         overlayColor != oldWidget.overlayColor ||
         labelTextStyle != oldWidget.labelTextStyle ||
+        iconTheme != oldWidget.iconTheme ||
         labelPadding != oldWidget.labelPadding ||
         onTap != oldWidget.onTap;
   }

--- a/lib/src/navigation_bar/navigation_bar.dart
+++ b/lib/src/navigation_bar/navigation_bar.dart
@@ -315,6 +315,7 @@ class NavigationBar extends StatelessWidget {
                 indicatorColor: indicatorColor,
                 indicatorShape: effectiveIndicatorShape,
                 overlayColor: overlayColor,
+                iconTheme: navigationBarTheme.iconTheme,
                 labelTextStyle: labelTextStyle,
                 labelPadding: labelPadding,
                 onTap: destination.enabled ? _handleTap.call(i) : () {},

--- a/lib/src/navigation_bar/theme_defaults.dart
+++ b/lib/src/navigation_bar/theme_defaults.dart
@@ -79,7 +79,7 @@ class _NavigationBarDefaultsM2 extends c.NavigationBarThemeData {
 
   @override
   WidgetStateProperty<Color?>? get destinationOverlayColor {
-    return overlayColor;
+    return null;
   }
 }
 
@@ -162,6 +162,6 @@ class _NavigationBarDefaultsM3 extends c.NavigationBarThemeData {
 
   @override
   WidgetStateProperty<Color?>? get destinationOverlayColor {
-    return overlayColor;
+    return null;
   }
 }

--- a/lib/src/navigation_rail/destination_widgets/destination_shared_state.dart
+++ b/lib/src/navigation_rail/destination_widgets/destination_shared_state.dart
@@ -88,14 +88,13 @@ class _WrappedRailDestinationState extends State<WrappedRailDestination> {
   Widget build(BuildContext context) {
     final CustomNavigationRailThemeData? maybeExplicitRailTheme =
         NavigationRailTheme.maybeOf(context);
-    final CustomNavigationRailThemeData explicitRailTheme =
-        maybeExplicitRailTheme ?? const CustomNavigationRailThemeData();
     final CustomNavigationRailThemeData railTheme =
-        NavigationRailTheme.of(context);
+        maybeExplicitRailTheme ?? const CustomNavigationRailThemeData();
+
     final WidgetStateProperty<Color?>? effectivedestinationOverlayColor =
-        explicitRailTheme.destinationOverlayColor;
+        railTheme.destinationOverlayColor;
     final bool hasExplicitNavigationItemIndicatorShape =
-        explicitRailTheme.destinationIndicatorShape != null;
+        railTheme.destinationIndicatorShape != null;
     final bool hasExplicitCustomInkOverride =
         effectivedestinationOverlayColor != null ||
             hasExplicitNavigationItemIndicatorShape;
@@ -134,14 +133,12 @@ class _WrappedRailDestinationState extends State<WrappedRailDestination> {
                 : effectivedestinationOverlayColor ?? fullItemOverlayColor);
     final ShapeBorder? effectiveNavigationItemIndicatorShape =
         useFrameworkDefaultInk
-            ? (explicitRailTheme.destinationIndicatorShape ??
-                explicitRailTheme.indicatorShape ??
+            ? (railTheme.destinationIndicatorShape ??
                 railTheme.indicatorShape ??
                 const StadiumBorder())
             : (disableFullItemInk
                 ? null
-                : explicitRailTheme.destinationIndicatorShape ??
-                    explicitRailTheme.indicatorShape ??
+                : railTheme.destinationIndicatorShape ??
                     railTheme.indicatorShape ??
                     const StadiumBorder());
 
@@ -152,8 +149,16 @@ class _WrappedRailDestinationState extends State<WrappedRailDestination> {
         : (widget.minWidth < widget.indicatorWidth
             ? widget.minWidth
             : widget.indicatorWidth);
-    final double selectedIndicatorHeight =
-        widget.material3 ? _kIndicatorHeight : widget.indicatorWidth;
+
+    final double largeIconIndicatorCompensation =
+        ((railTheme.iconTheme?.resolve({})?.size ?? 0) - _kIndicatorHeight)
+            .clamp(0.0, double.infinity);
+
+    final double selectedIndicatorHeight = widget.material3
+        ? _kIndicatorHeight + largeIconIndicatorCompensation
+        : widget.indicatorWidth;
+    final double indicatorCenteringHeight =
+        widget.material3 ? selectedIndicatorHeight : _kIndicatorHeight;
 
     final Widget iconInteractionIndicator = widget.centerIndicatorHorizontally
         ? Positioned.fill(
@@ -161,7 +166,8 @@ class _WrappedRailDestinationState extends State<WrappedRailDestination> {
               alignment: Alignment.topCenter,
               child: Padding(
                 padding: EdgeInsets.only(
-                  top: widget.indicatorOffset.dy - _kIndicatorHeight / 2,
+                  top: widget.indicatorOffset.dy -
+                      (indicatorCenteringHeight / 2),
                 ),
                 child: NavigationIndicator(
                   animation: widget.selectionAnimation,
@@ -176,7 +182,7 @@ class _WrappedRailDestinationState extends State<WrappedRailDestination> {
         : Positioned.directional(
             textDirection: widget.textDirection,
             start: widget.indicatorOffset.dx - selectedIndicatorWidth / 2,
-            top: widget.indicatorOffset.dy - _kIndicatorHeight / 2,
+            top: widget.indicatorOffset.dy - (indicatorCenteringHeight / 2),
             child: NavigationIndicator(
               animation: widget.selectionAnimation,
               color: widget.indicatorColor,
@@ -211,6 +217,8 @@ class _WrappedRailDestinationState extends State<WrappedRailDestination> {
             applyXOffset: widget.applyXOffset,
             textDirection: widget.textDirection,
             statesController: _statesController,
+            indicatorHeight:
+                widget.material3 ? selectedIndicatorHeight : _kIndicatorHeight,
             child: widget.child,
           ),
         ),

--- a/lib/src/navigation_rail/destination_widgets/destination_shared_state.dart
+++ b/lib/src/navigation_rail/destination_widgets/destination_shared_state.dart
@@ -150,8 +150,9 @@ class _WrappedRailDestinationState extends State<WrappedRailDestination> {
             ? widget.minWidth
             : widget.indicatorWidth);
 
+    const double kDefaultIconSize = 24.0;
     final double largeIconIndicatorCompensation =
-        ((railTheme.iconTheme?.resolve({})?.size ?? 0) - _kIndicatorHeight)
+        ((railTheme.iconTheme?.resolve({})?.size ?? 0) - kDefaultIconSize)
             .clamp(0.0, double.infinity);
 
     final double selectedIndicatorHeight = widget.material3

--- a/lib/src/navigation_rail/destination_widgets/destination_widget.dart
+++ b/lib/src/navigation_rail/destination_widgets/destination_widget.dart
@@ -12,6 +12,7 @@ const double _verticalDestinationSpacingM3 = 12.0;
 const double _horizontalDestinationSpacingM3 = 12.0;
 const double _kRailIndicatorWidth = 56.0;
 const double _kRailIconSlotHeight = 44.0;
+const double _kDefaultIconSize = 24.0;
 
 class RailDestination extends StatefulWidget {
   const RailDestination({
@@ -156,6 +157,8 @@ class _RailDestinationState extends State<RailDestination>
     );
 
     // Label type is a layout-level concern, resolved here after theming.
+    final NavigationRailThemeData? maybeExplicitRailTheme =
+        NavigationRailTheme.maybeOf(context);
     final NavigationRailThemeData railTheme = NavigationRailTheme.of(context);
     final NavigationRailThemeData defaults = navigationRailDefaultsFor(context);
     final NavigationRailLabelType labelType =
@@ -175,14 +178,19 @@ class _RailDestinationState extends State<RailDestination>
 
     // Indicator vertical centering when icon exceeds indicator height.
     final double largeIconIndicatorCompensation =
-        (data.resolvedIconSize! - _kIndicatorHeight)
+        (data.resolvedIconSize! - _kDefaultIconSize)
             .clamp(0.0, double.infinity);
-
+    final bool alignIndicatorToCustomLargeIconCenter =
+        maybeExplicitRailTheme?.iconTheme != null;
+    final double indicatorOffsetBaseline = alignIndicatorToCustomLargeIconCenter
+        ? _kDefaultIconSize
+        : _kIndicatorHeight;
     final bool isLargeIconSize = data.resolvedIconSize != null &&
-        data.resolvedIconSize! > _kIndicatorHeight;
+        data.resolvedIconSize! > indicatorOffsetBaseline;
 
-    final double indicatorVerticalOffset =
-        isLargeIconSize ? (data.resolvedIconSize! - _kIndicatorHeight) / 2 : 0;
+    final double indicatorVerticalOffset = isLargeIconSize
+        ? (data.resolvedIconSize! - indicatorOffsetBaseline) / 2
+        : 0;
 
     Offset indicatorOffset = data.indicatorOffset;
 

--- a/lib/src/navigation_rail/destination_widgets/destination_widget.dart
+++ b/lib/src/navigation_rail/destination_widgets/destination_widget.dart
@@ -174,12 +174,18 @@ class _RailDestinationState extends State<RailDestination>
         : railTheme.tooltipTriggerWhenLabelHidden ?? railTheme.tooltipTrigger;
 
     // Indicator vertical centering when icon exceeds indicator height.
+    final double largeIconIndicatorCompensation =
+        (data.resolvedIconSize! - _kIndicatorHeight)
+            .clamp(0.0, double.infinity);
+
     final bool isLargeIconSize = data.resolvedIconSize != null &&
         data.resolvedIconSize! > _kIndicatorHeight;
+
     final double indicatorVerticalOffset =
         isLargeIconSize ? (data.resolvedIconSize! - _kIndicatorHeight) / 2 : 0;
 
     Offset indicatorOffset = data.indicatorOffset;
+
     bool applyXOffset = false;
 
     Widget content;
@@ -200,7 +206,8 @@ class _RailDestinationState extends State<RailDestination>
         );
 
         final Widget iconPart = NavigationIcon(
-          height: data.material3 ? _kRailIconSlotHeight : data.minWidth,
+          height: (data.material3 ? _kRailIconSlotHeight : data.minWidth) +
+              largeIconIndicatorCompensation,
           icon: data.themedIcon,
           minWidth: data.minWidth,
           material3: data.material3,
@@ -232,7 +239,9 @@ class _RailDestinationState extends State<RailDestination>
               );
             }
             content = Container(
-              constraints: BoxConstraints(minWidth: data.minWidth),
+              constraints: BoxConstraints(
+                minWidth: data.minWidth,
+              ),
               padding: widget.padding,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -243,7 +252,7 @@ class _RailDestinationState extends State<RailDestination>
                         : _verticalDestinationPaddingWithLabel,
                   ),
                   SizedBox(
-                    height: _kIndicatorHeight,
+                    height: _kIndicatorHeight + largeIconIndicatorCompensation,
                     child: Center(child: data.themedIcon),
                   ),
                   SizedBox(
@@ -373,7 +382,8 @@ class _RailDestinationState extends State<RailDestination>
                 SizedBox(height: data.material3 ? 0 : verticalPadding),
                 data.material3
                     ? SizedBox(
-                        height: _kIndicatorHeight,
+                        height:
+                            _kIndicatorHeight + largeIconIndicatorCompensation,
                         child: Center(child: data.themedIcon),
                       )
                     : data.themedIcon,
@@ -448,7 +458,8 @@ class _RailDestinationState extends State<RailDestination>
               ),
               data.material3
                   ? SizedBox(
-                      height: _kIndicatorHeight,
+                      height:
+                          _kIndicatorHeight + largeIconIndicatorCompensation,
                       child: Center(child: data.themedIcon),
                     )
                   : data.themedIcon,

--- a/lib/src/navigation_rail/destination_widgets/indicator_ink_well.dart
+++ b/lib/src/navigation_rail/destination_widgets/indicator_ink_well.dart
@@ -8,6 +8,7 @@ class _IndicatorInkWell extends InkResponse {
     required this.textDirection,
     required this.indicatorWidth,
     required this.disableFullItemInk,
+    this.indicatorHeight = 32.0,
     super.child,
     super.onTap,
     super.statesController,
@@ -29,9 +30,8 @@ class _IndicatorInkWell extends InkResponse {
   final bool applyXOffset;
   final TextDirection textDirection;
   final double indicatorWidth;
+  final double indicatorHeight;
   final bool disableFullItemInk;
-
-  static const double _indicatorHeight = 32.0;
 
   @override
   RectCallback? getRectCallback(RenderBox referenceBox) {
@@ -45,7 +45,7 @@ class _IndicatorInkWell extends InkResponse {
       return () => Rect.fromCenter(
             center: Offset(indicatorHorizontalCenter, indicatorOffset.dy),
             width: indicatorWidth,
-            height: _indicatorHeight,
+            height: indicatorHeight,
           );
     }
     return () => Rect.fromLTRB(

--- a/lib/src/navigation_rail/navigation_rail.dart
+++ b/lib/src/navigation_rail/navigation_rail.dart
@@ -464,11 +464,14 @@ class _NavigationRailState extends State<NavigationRail>
         navigationRailTheme.selectedLabelTextStyle ??
         defaults.selectedLabelTextStyle!;
     final IconThemeData unselectedIconTheme = widget.unselectedIconTheme ??
+        navigationRailTheme.iconTheme?.resolve({}) ??
         navigationRailTheme.unselectedIconTheme ??
         defaults.unselectedIconTheme!;
     final IconThemeData selectedIconTheme = widget.selectedIconTheme ??
+        navigationRailTheme.iconTheme?.resolve({WidgetState.selected}) ??
         navigationRailTheme.selectedIconTheme ??
         defaults.selectedIconTheme!;
+
     final double groupAlignment = widget.groupAlignment ??
         navigationRailTheme.groupAlignment ??
         defaults.groupAlignment!;

--- a/lib/src/navigation_shared/destination_surface_strategy.dart
+++ b/lib/src/navigation_shared/destination_surface_strategy.dart
@@ -178,6 +178,11 @@ class RailDestinationStrategy extends DestinationSurfaceStrategy {
         railTheme.iconTheme?.resolve({WidgetState.selected})?.size ??
         navigationRailDefaultsFor(context).unselectedIconTheme!.size!;
 
+    assert(
+      railIconSize <= 72.0,
+      "NavigationRailThemeData.iconTheme size must be <= 72.0.",
+    );
+
     // In M2 with indicator enabled, selected icon color should contrast with
     // the indicator fill. Keep explicit widget/theme icon overrides intact.
     final bool hasSelectedIconOverride =
@@ -305,6 +310,15 @@ class BarDestinationStrategy extends DestinationSurfaceStrategy {
     final bool material3 = theme.useMaterial3;
     final IconThemeData iconTheme = barTheme.iconTheme?.resolve(widgetState) ??
         defaults.iconTheme!.resolve(widgetState)!;
+
+    final double barIconSize = barTheme.iconTheme?.resolve(widgetState)?.size ??
+        barTheme.iconTheme?.resolve({WidgetState.selected})?.size ??
+        defaults.iconTheme!.resolve(widgetState)!.size!;
+
+    assert(
+      barIconSize <= 60.0,
+      "NavigationBarThemeData.iconTheme size must be <= 60.0.",
+    );
 
     final Widget themedIcon = IconTheme.merge(
       data: iconTheme,

--- a/lib/src/navigation_shared/destination_surface_strategy.dart
+++ b/lib/src/navigation_shared/destination_surface_strategy.dart
@@ -170,6 +170,14 @@ class RailDestinationStrategy extends DestinationSurfaceStrategy {
             railTheme.selectedIconTheme ??
             defaults.selectedIconTheme!;
 
+    final double railIconSize = railTheme.iconTheme
+            ?.resolve(
+              input.selected ? {WidgetState.selected} : {},
+            )
+            ?.size ??
+        railTheme.iconTheme?.resolve({WidgetState.selected})?.size ??
+        navigationRailDefaultsFor(context).unselectedIconTheme!.size!;
+
     // In M2 with indicator enabled, selected icon color should contrast with
     // the indicator fill. Keep explicit widget/theme icon overrides intact.
     final bool hasSelectedIconOverride =
@@ -201,6 +209,7 @@ class RailDestinationStrategy extends DestinationSurfaceStrategy {
       data: input.disabled
           ? iconTheme.copyWith(
               color: theme.colorScheme.onSurface.withValues(alpha: 0.38),
+              size: railIconSize,
             )
           : iconTheme,
       child: input.icon,
@@ -319,13 +328,38 @@ class BarDestinationStrategy extends DestinationSurfaceStrategy {
         barTheme.indicatorShape ??
         defaults.indicatorShape!;
 
-    // --- Interaction colors ---
-    // Bar uses the indicator color (or primary) as the base for ripple/hover.
-    final Color splashBase = barTheme.indicatorColor ??
-        defaults.indicatorColor ??
-        theme.colorScheme.secondaryContainer;
-    final bool splashAlphaModified =
-        (splashBase.a * 255.0).round().clamp(0, 255) < 255;
+// --- Interaction colors ---
+    // Define the states combining selection with user interactions
+    final Set<WidgetState> hoverStates = {
+      if (input.disabled) WidgetState.disabled,
+      if (input.selected && !input.disabled) WidgetState.selected,
+      WidgetState.hovered,
+    };
+
+    final Set<WidgetState> pressedStates = {
+      if (input.disabled) WidgetState.disabled,
+      if (input.selected && !input.disabled) WidgetState.selected,
+      WidgetState.pressed,
+    };
+
+    // Resolve custom overlay colors from the theme if provided
+    Color? hoverColor = barTheme.overlayColor?.resolve(hoverStates);
+    Color? splashColor = barTheme.overlayColor?.resolve(pressedStates) ??
+        barTheme.overlayColor?.resolve({...pressedStates, WidgetState.focused});
+
+    // Fallback to default indicator-based behavior if no overlayColor is defined
+    if (hoverColor == null || splashColor == null) {
+      final Color splashBase = barTheme.indicatorColor ??
+          defaults.indicatorColor ??
+          theme.colorScheme.secondaryContainer;
+      final bool splashAlphaModified =
+          (splashBase.a * 255.0).round().clamp(0, 255) < 255;
+
+      hoverColor ??=
+          splashAlphaModified ? splashBase : splashBase.withValues(alpha: 0.04);
+      splashColor ??=
+          splashAlphaModified ? splashBase : splashBase.withValues(alpha: 0.12);
+    }
 
     return DestinationBuildData(
       themedIcon: themedIcon,
@@ -341,10 +375,9 @@ class BarDestinationStrategy extends DestinationSurfaceStrategy {
       extendedAnimation:
           input.extendedTransitionAnimation ?? kAlwaysCompleteAnimation,
       indicatorOffset: const Offset(_kBarIndicatorWidth / 2, 0),
-      splashColor:
-          splashAlphaModified ? splashBase : splashBase.withValues(alpha: 0.12),
-      hoverColor:
-          splashAlphaModified ? splashBase : splashBase.withValues(alpha: 0.04),
+      splashColor: splashColor,
+      hoverColor: hoverColor,
+      resolvedIconSize: iconTheme.size,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: custom_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 5.0.1
+version: 5.1.0
 issue_tracker: https://github.com/hanskokx/custom_adaptive_scaffold/issues
 repository: https://github.com/hanskokx/custom_adaptive_scaffold
 

--- a/test/navigation_destination_test.dart
+++ b/test/navigation_destination_test.dart
@@ -10,6 +10,8 @@
 //     structurally parity outputs (both resolve a themed icon + styled label).
 
 import "package:custom_adaptive_scaffold/custom_adaptive_scaffold.dart";
+import "package:custom_adaptive_scaffold/src/navigation_shared/destination_surface_strategy.dart";
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart"
     hide
         NavigationBar,
@@ -17,7 +19,8 @@ import "package:flutter/material.dart"
         NavigationDestination,
         NavigationRailDestination,
         NavigationRail,
-        NavigationRailThemeData;
+        NavigationRailThemeData,
+        NavigationBarThemeData;
 import "package:flutter_test/flutter_test.dart";
 
 // ---------------------------------------------------------------------------
@@ -834,5 +837,221 @@ void main() {
       expect(barTaps, 0, reason: "bar disabled destination must not fire");
       expect(railTaps, 0, reason: "rail disabled destination must not fire");
     });
+
+    testWidgets(
+        "rail explicit iconTheme keeps indicator centered on large icon",
+        (WidgetTester tester) async {
+      const double iconSize = 40.0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            useMaterial3: true,
+            navigationRailTheme: const NavigationRailThemeData(
+              iconTheme: WidgetStatePropertyAll<IconThemeData>(
+                IconThemeData(size: iconSize),
+              ),
+            ),
+          ),
+          home: Scaffold(
+            body: Row(
+              children: [
+                NavigationRail(
+                  selectedIndex: 0,
+                  destinations: const [
+                    NavigationRailDestination(
+                      icon: Icon(Icons.home),
+                      label: Text("Home"),
+                    ),
+                    NavigationRailDestination(
+                      icon: Icon(Icons.search),
+                      label: Text("Search"),
+                    ),
+                  ],
+                ),
+                const Expanded(child: SizedBox()),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final TestGesture gesture =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer();
+      await gesture.moveTo(tester.getCenter(find.byIcon(Icons.home)));
+      await tester.pumpAndSettle();
+
+      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
+        (RenderObject object) =>
+            object.runtimeType.toString() == "_RenderInkFeatures",
+      );
+
+      const Rect expectedRect = Rect.fromLTRB(12.0, 6.0, 68.0, 54.0);
+      final Offset iconCenter = tester.getCenter(find.byIcon(Icons.home));
+      final Offset indicatorCenter = Offset(
+        expectedRect.center.dx,
+        expectedRect.center.dy + 8.0,
+      );
+
+      expect(
+        inkFeatures,
+        paints..rect(rect: expectedRect),
+      );
+      expect(
+        (iconCenter.dx - indicatorCenter.dx).abs(),
+        lessThanOrEqualTo(0.5),
+      );
+      expect(
+        (iconCenter.dy - indicatorCenter.dy).abs(),
+        lessThanOrEqualTo(0.5),
+      );
+    });
+
+    testWidgets("bar explicit iconTheme expands indicator slot for large icons",
+        (WidgetTester tester) async {
+      const double iconSize = 40.0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            useMaterial3: true,
+            navigationBarTheme: const CustomNavigationBarThemeData(
+              iconTheme: WidgetStatePropertyAll<IconThemeData>(
+                IconThemeData(size: iconSize),
+              ),
+            ),
+          ),
+          home: Scaffold(
+            bottomNavigationBar: NavigationBar(
+              selectedIndex: 0,
+              destinations: const [
+                NavigationDestination(icon: Icon(Icons.home), label: "Home"),
+                NavigationDestination(
+                  icon: Icon(Icons.search),
+                  label: "Search",
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final Finder iconContainer = find.ancestor(
+        of: find.byIcon(Icons.home),
+        matching: find.byType(SizedBox),
+      );
+
+      final Iterable<SizedBox> sizedBoxes =
+          tester.widgetList<SizedBox>(iconContainer);
+      final bool hasExpandedIndicatorSlot = sizedBoxes.any(
+        (SizedBox box) => box.height != null && box.height! > 32.0,
+      );
+
+      expect(
+        hasExpandedIndicatorSlot,
+        isTrue,
+        reason:
+            "explicit large icon theme should expand bar indicator/icon slot",
+      );
+    });
+
+    testWidgets(
+      "bar theme iconTheme size above 60 throws assertion",
+      (WidgetTester tester) async {
+        late BuildContext context;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              useMaterial3: true,
+              navigationBarTheme: const CustomNavigationBarThemeData(
+                iconTheme: WidgetStatePropertyAll<IconThemeData>(
+                  IconThemeData(size: 61.0),
+                ),
+              ),
+            ),
+            home: Builder(
+              builder: (BuildContext c) {
+                context = c;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        const BarDestinationStrategy strategy = BarDestinationStrategy();
+
+        expect(
+          () => strategy.resolve(
+            context,
+            const DestinationResolveInput(
+              icon: Icon(Icons.home),
+              label: Text("Home"),
+              selected: true,
+              disabled: false,
+              destinationAnimation: kAlwaysCompleteAnimation,
+            ),
+          ),
+          throwsA(
+            isA<AssertionError>().having(
+              (AssertionError e) => e.message.toString(),
+              "message",
+              contains("iconTheme size must be <= 60.0"),
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      "rail theme iconTheme size above 72 throws assertion",
+      (WidgetTester tester) async {
+        late BuildContext context;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              useMaterial3: true,
+              navigationRailTheme: const NavigationRailThemeData(
+                iconTheme: WidgetStatePropertyAll<IconThemeData>(
+                  IconThemeData(size: 73.0),
+                ),
+              ),
+            ),
+            home: Builder(
+              builder: (BuildContext c) {
+                context = c;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        const RailDestinationStrategy strategy = RailDestinationStrategy();
+
+        expect(
+          () => strategy.resolve(
+            context,
+            const DestinationResolveInput(
+              icon: Icon(Icons.home),
+              label: Text("Home"),
+              selected: true,
+              disabled: false,
+              destinationAnimation: kAlwaysCompleteAnimation,
+            ),
+          ),
+          throwsA(
+            isA<AssertionError>().having(
+              (AssertionError e) => e.message.toString(),
+              "message",
+              contains("iconTheme size must be <= 72.0"),
+            ),
+          ),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

This PR finishes the large-icon support work for the package-owned navigation components while preserving Flutter parity by default.

It improves explicit large-icon handling for both `NavigationBar` and `NavigationRail`, refines rail indicator alignment for oversized icons, adds guardrails around supported icon sizes, and updates docs/release notes for `v5.1.0`.

## What changed

- Improved explicit large-icon support for `NavigationBar`
  - Indicator/icon slot sizing now expands correctly for explicit themed icon sizes.
- Improved explicit large-icon support for `NavigationRail`
  - Added package-owned `NavigationRailThemeData.iconTheme` support.
  - Refined rail destination spacing and indicator centering for large icons.
- Preserved framework-mirror behavior by default
  - Custom ink / indicator behavior only applies when package-specific extensions are explicitly configured.
  - `NavigationBarTheme.maybeOf(context)` now respects explicit theme intent more accurately.
- Added size guardrails for themed icons
  - `NavigationRailThemeData.iconTheme` is capped at `72.0`.
  - `NavigationBarThemeData.iconTheme` is capped at `60.0`.
- Updated documentation
  - README now documents extended theme behavior and the supported max icon sizes.
  - CHANGELOG includes the `5.1.0` release notes.

## Testing

- Added regression coverage for:
  - large-icon `NavigationBar` indicator slot expansion
  - `NavigationRailThemeData.iconTheme` size assertion
  - `NavigationBarThemeData.iconTheme` size assertion
- Verified focused destination tests and the full test suite pass.

## Notes

- This keeps default behavior aligned with the upstream Flutter widgets unless package-specific extension fields are used.
- The new icon-size assertions are intended to protect indicator/layout assumptions rather than silently render unsupported oversized themes.