### PR TITLE
Add M3 badge support to `NavigationDestination` (`NavigationBar` + `NavigationRail`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.2.0
+
+- **[FEAT]** Added M3 small and large badge support to `NavigationDestination`, `NavigationBar`, and `NavigationRail`.
+  - `NavigationDestination.badge` (`int?`): set to a positive integer to show a badge. Values greater than `99` automatically display as `"99+"`. Must be `null` or greater than `0`.
+  - `NavigationDestination.badgeStyle` (`NavigationBadgeStyle`): controls the badge presentation.
+    - `count` (default) — shows the numeric value.
+    - `dot` — shows a small dot indicator regardless of the count.
+    - `hidden` — suppresses the badge entirely while retaining the count value in the widget tree.
+  - `NavigationRailThemeData.badgeThemeData` and `NavigationBarThemeData.badgeThemeData` (`BadgeThemeData?`): theme-level badge styling (color, text style, size) scoped to navigation destinations.
+
 ## 5.1.0
 
 - **[FEAT]** Improved large icon support for `NavigationBar` and `NavigationRail`.

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ The package's `NavigationDestination` is a full base class (not just a wrapper) 
 
 `NavigationDestination` supports M3-compliant small (dot) and large (labeled) badges via two properties:
 
-| Property     | Type                   | Description                                                                                                                                   |
-| ------------ | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `badge`      | `int?`                 | Badge count. `null` = no badge. Values > `99` display as `"99+"`. Must be > 0.                                                                |
-| `badgeStyle` | `NavigationBadgeStyle` | `count` (default) shows the number; `dot` shows a small indicator; `hidden` suppresses the visual while keeping the count in the widget tree. |
+| Property     | Type                   | Description                                                                                                                                |
+| ------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `badge`      | `int?`                 | Badge count. `null` = no badge. Values > `99` display as `"99+"`. Must be > 0.                                                             |
+| `badgeStyle` | `NavigationBadgeStyle` | `count` (default) shows the number; `dot` shows a small indicator; `hidden` suppresses the visual while keeping the count in widget state. |
 
 ```dart
 // Large badge — shows "5":

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Modifications have been made to the original source code that provide some addit
   - [How Is This Different From Flutter?](#how-is-this-different-from-flutter)
     - [Extended theme data](#extended-theme-data)
     - [Richer `NavigationDestination` base class](#richer-navigationdestination-base-class)
+    - [Badges](#badges)
     - [New public APIs not present in Flutter](#new-public-apis-not-present-in-flutter)
     - [Extra `NavigationRail` parameters](#extra-navigationrail-parameters)
     - [Collapsed-pane controller](#collapsed-pane-controller)
@@ -109,16 +110,17 @@ When package-specific extension properties are not set, bar/rail behavior follow
 Both `NavigationBarThemeData` and `NavigationRailThemeData` are package-owned classes that implement the Flutter framework interfaces, so they are usable
 everywhere Flutter's types are expected. They add:
 
-| Property                         | New vs Flutter | Description                                   |
-| -------------------------------- | -------------- | --------------------------------------------- |
-| `margin`                         | ✓              | Margin around each navigation item            |
-| `padding`                        | ✓              | Padding inside each navigation item           |
-| `destinationOverlayColor`        | ✓              | Full-item ink/highlight color by widget state |
-| `navigationItemIndicatorShape`   | ✓              | Shape for the full-item ink well              |
-| `tooltipOffset`                  | ✓              | X/Y offset for tooltip popovers               |
-| `tooltipTrigger`                 | ✓              | Which gesture triggers the tooltip            |
-| `tooltipTriggerWhenLabelVisible` | ✓              | Override trigger when label is shown          |
-| `tooltipTriggerWhenLabelHidden`  | ✓              | Override trigger when label is hidden         |
+| Property                         | New vs Flutter | Description                                                    |
+| -------------------------------- | -------------- | -------------------------------------------------------------- |
+| `margin`                         | ✓              | Margin around each navigation item                             |
+| `padding`                        | ✓              | Padding inside each navigation item                            |
+| `destinationOverlayColor`        | ✓              | Full-item ink/highlight color by widget state                  |
+| `navigationItemIndicatorShape`   | ✓              | Shape for the full-item ink well                               |
+| `tooltipOffset`                  | ✓              | X/Y offset for tooltip popovers                                |
+| `tooltipTrigger`                 | ✓              | Which gesture triggers the tooltip                             |
+| `tooltipTriggerWhenLabelVisible` | ✓              | Override trigger when label is shown                           |
+| `tooltipTriggerWhenLabelHidden`  | ✓              | Override trigger when label is hidden                          |
+| `badgeThemeData`                 | ✓              | Badge colors, text style, and size for navigation destinations |
 
 `NavigationRailThemeData` additionally provides:
 
@@ -129,8 +131,44 @@ everywhere Flutter's types are expected. They add:
 
 ### Richer `NavigationDestination` base class
 
-The package's `NavigationDestination` is a full base class (not just a wrapper) with `margin`, `padding`, `indicatorColor`, `indicatorShape`, and `disabled`.
+The package's `NavigationDestination` is a full base class (not just a wrapper) with `margin`, `padding`, `indicatorColor`, `indicatorShape`, `disabled`, `badge`, and `badgeStyle`.
 `CustomNavigationDestination` is a typedef alias for it.
+
+### Badges
+
+`NavigationDestination` supports M3-compliant small (dot) and large (labeled) badges via two properties:
+
+| Property     | Type                   | Description                                                                                                                                   |
+| ------------ | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `badge`      | `int?`                 | Badge count. `null` = no badge. Values > `99` display as `"99+"`. Must be > 0.                                                                |
+| `badgeStyle` | `NavigationBadgeStyle` | `count` (default) shows the number; `dot` shows a small indicator; `hidden` suppresses the visual while keeping the count in the widget tree. |
+
+```dart
+// Large badge — shows "5":
+NavigationDestination(icon: Icon(Icons.inbox), label: 'Inbox', badge: 5)
+
+// Automatically capped — shows "99+":
+NavigationDestination(icon: Icon(Icons.inbox), label: 'Inbox', badge: 150)
+
+// Small dot badge:
+NavigationDestination(icon: Icon(Icons.inbox), label: 'Inbox',
+  badge: 1, badgeStyle: NavigationBadgeStyle.dot)
+
+// Hidden — retains the count in widget state, suppresses the visual:
+NavigationDestination(icon: Icon(Icons.inbox), label: 'Inbox',
+  badge: 3, badgeStyle: NavigationBadgeStyle.hidden)
+```
+
+Badge appearance can be themed per navigation surface via `badgeThemeData` on `NavigationRailThemeData` or `NavigationBarThemeData`. This wraps the badge in a [`BadgeTheme`](https://api.flutter.dev/flutter/material/BadgeTheme-class.html), so all `BadgeThemeData` fields (background color, text style, size, alignment) are available:
+
+```dart
+NavigationRailTheme(
+  data: NavigationRailThemeData(
+    badgeThemeData: BadgeThemeData(backgroundColor: Colors.red[700]),
+  ),
+  child: NavigationRail(/* … */),
+)
+```
 
 ### New public APIs not present in Flutter
 

--- a/example/lib/adaptive_scaffold_demo.dart
+++ b/example/lib/adaptive_scaffold_demo.dart
@@ -112,16 +112,20 @@ class _MyHomePageState extends State<MyHomePage> {
           icon: Icon(Icons.inbox_outlined),
           selectedIcon: Icon(Icons.inbox),
           label: "Inbox",
+          badge: 150,
         ),
         NavigationDestination(
           icon: Icon(Icons.article_outlined),
           selectedIcon: Icon(Icons.article),
           label: "Articles",
+          badge: 1,
         ),
         NavigationDestination(
           icon: Icon(Icons.chat_outlined),
           selectedIcon: Icon(Icons.chat),
           label: "Chat",
+          badge: 1,
+          badgeStyle: NavigationBadgeStyle.dot,
         ),
         NavigationDestination(
           icon: Icon(Icons.video_call_outlined),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -227,14 +227,18 @@ class _MyHomePageState extends State<MyHomePage>
       NavigationDestination(
         label: "Inbox",
         icon: Icon(Icons.inbox),
+        badge: 150,
       ),
       NavigationDestination(
         label: "Articles",
         icon: Icon(Icons.article_outlined),
+        badge: 1,
       ),
       NavigationDestination(
         label: "Chat",
         icon: Icon(Icons.chat_bubble_outline),
+        badge: 1,
+        badgeStyle: NavigationBadgeStyle.dot,
       ),
       NavigationDestination(
         label: "Video",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -383,7 +383,7 @@ class _MyHomePageState extends State<MyHomePage>
           secondaryBody: _navigationIndex == 0
               ? SlotLayout(
                   config: <Breakpoint, SlotLayoutConfig?>{
-                    Breakpoints.mediumAndUp: SlotLayout.from(
+                    Breakpoints.mediumLargeAndUp: SlotLayout.from(
                       // This overrides the default behavior of the secondaryBody
                       // disappearing as it is animating out.
                       outAnimation: AdaptiveScaffold.stayOnScreen,
@@ -593,23 +593,49 @@ class _ItemList extends StatelessWidget {
           if (!Breakpoints.mediumAndUp.isActive(context) && items.isNotEmpty)
             Padding(
               padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: FilledButton.tonalIcon(
-                  onPressed: () {
-                    final _Item firstItem = items.first;
-                    selectCard(_allItems.indexOf(firstItem));
-                    Navigator.of(context).pushNamed(
-                      _ExtractRouteArguments.routeName,
-                      arguments: _ScreenArguments(
-                        item: firstItem,
-                        selectCard: selectCard,
-                      ),
-                    );
-                  },
-                  icon: const Icon(Icons.swap_horiz),
-                  label: const Text("Show secondary pane"),
-                ),
+              child: LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  final bool compactButton = constraints.maxWidth < 240;
+
+                  return Align(
+                    alignment: Alignment.centerLeft,
+                    child: FilledButton(
+                      onPressed: () {
+                        final _Item firstItem = items.first;
+                        selectCard(_allItems.indexOf(firstItem));
+                        Navigator.of(context).pushNamed(
+                          _ExtractRouteArguments.routeName,
+                          arguments: _ScreenArguments(
+                            item: firstItem,
+                            selectCard: selectCard,
+                          ),
+                        );
+                      },
+                      style: compactButton
+                          ? FilledButton.styleFrom(
+                              minimumSize: const Size(0, 40),
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 12),
+                            )
+                          : null,
+                      child: compactButton
+                          ? const Icon(Icons.swap_horiz)
+                          : const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                Icon(Icons.swap_horiz),
+                                SizedBox(width: 8),
+                                Flexible(
+                                  child: Text(
+                                    "Show secondary pane",
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                    ),
+                  );
+                },
               ),
             ),
           Expanded(
@@ -677,21 +703,18 @@ class _ItemListTile extends StatelessWidget {
                 LayoutBuilder(
                   builder: (BuildContext context, BoxConstraints constraints) {
                     final double availableWidth = constraints.maxWidth;
-                    final double avatarDiameter =
-                        availableWidth.isFinite && availableWidth > 0
-                            ? (availableWidth - 8).clamp(20.0, 36.0).toDouble()
-                            : 36.0;
-                    final bool showTrailing =
-                        !availableWidth.isFinite || availableWidth >= 220;
+                    if (availableWidth.isFinite && availableWidth < 48) {
+                      final double fallbackAvatarDiameter =
+                          availableWidth.clamp(0.0, 20.0).toDouble();
 
-                    return ListTile(
-                      contentPadding: EdgeInsets.zero,
-                      minLeadingWidth: avatarDiameter,
-                      horizontalTitleGap: showTrailing ? 12 : 8,
-                      leading: SizedBox.square(
-                        dimension: avatarDiameter,
+                      if (fallbackAvatarDiameter <= 0) {
+                        return const SizedBox.shrink();
+                      }
+
+                      return SizedBox.square(
+                        dimension: fallbackAvatarDiameter,
                         child: CircleAvatar(
-                          radius: avatarDiameter / 2,
+                          radius: fallbackAvatarDiameter / 2,
                           child: Image.asset(
                             email.image,
                             width: 100,
@@ -699,39 +722,74 @@ class _ItemListTile extends StatelessWidget {
                             fit: BoxFit.cover,
                           ),
                         ),
-                      ),
-                      title: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Text(
-                            email.sender,
-                            style: Theme.of(context).textTheme.bodyLarge,
-                            softWrap: false,
-                            overflow: TextOverflow.clip,
+                      );
+                    }
+                    final bool compactHeader =
+                        availableWidth.isFinite && availableWidth < 180;
+                    final double avatarDiameter =
+                        availableWidth.isFinite && availableWidth > 0
+                            ? (availableWidth - (compactHeader ? 4 : 8))
+                                .clamp(20.0, compactHeader ? 28.0 : 36.0)
+                                .toDouble()
+                            : 36.0;
+                    final bool showTrailing =
+                        !availableWidth.isFinite || availableWidth >= 220;
+                    final double gap =
+                        compactHeader ? 4 : (showTrailing ? 12 : 8);
+
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: <Widget>[
+                        SizedBox.square(
+                          dimension: avatarDiameter,
+                          child: CircleAvatar(
+                            radius: avatarDiameter / 2,
+                            child: Image.asset(
+                              email.image,
+                              width: 100,
+                              height: 100,
+                              fit: BoxFit.cover,
+                            ),
                           ),
-                          const SizedBox(height: 3),
-                          Text(
-                            "${email.time} ago",
-                            style: Theme.of(context).textTheme.bodySmall,
-                            softWrap: false,
-                            overflow: TextOverflow.clip,
+                        ),
+                        SizedBox(width: gap),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              Text(
+                                email.sender,
+                                style: Theme.of(context).textTheme.bodyLarge,
+                                softWrap: false,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              const SizedBox(height: 3),
+                              Text(
+                                "${email.time} ago",
+                                style: Theme.of(context).textTheme.bodySmall,
+                                softWrap: false,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
+                          ),
+                        ),
+                        if (showTrailing) ...<Widget>[
+                          SizedBox(width: compactHeader ? 4 : 12),
+                          Container(
+                            padding: const EdgeInsets.all(8.0),
+                            decoration: const BoxDecoration(
+                              color: Colors.white,
+                              borderRadius:
+                                  BorderRadius.all(Radius.circular(50)),
+                            ),
+                            child: Icon(
+                              Icons.star_outline,
+                              color: Colors.grey[500],
+                            ),
                           ),
                         ],
-                      ),
-                      trailing: showTrailing
-                          ? Container(
-                              padding: const EdgeInsets.all(8.0),
-                              decoration: const BoxDecoration(
-                                color: Colors.white,
-                                borderRadius:
-                                    BorderRadius.all(Radius.circular(50)),
-                              ),
-                              child: Icon(
-                                Icons.star_outline,
-                                color: Colors.grey[500],
-                              ),
-                            )
-                          : null,
+                      ],
                     );
                   },
                 ),
@@ -963,62 +1021,80 @@ class _EmailTile extends StatelessWidget {
                 child: (bodyImage != "") ? Image.asset(bodyImage) : Container(),
               ),
               const SizedBox(height: 10),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: <Widget>[
-                  SizedBox(
-                    width: 126,
-                    child: OutlinedButton(
-                      onPressed: () {},
-                      style: ButtonStyle(
-                        shape: WidgetStateProperty.all(
-                          RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(30.0),
+              LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  final bool stackActions = constraints.maxWidth.isFinite &&
+                      constraints.maxWidth < 260;
+
+                  return Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: <Widget>[
+                      SizedBox(
+                        width: stackActions
+                            ? constraints.maxWidth
+                            : (constraints.maxWidth - 8) / 2,
+                        child: OutlinedButton(
+                          onPressed: () {},
+                          style: ButtonStyle(
+                            shape: WidgetStateProperty.all(
+                              RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(30.0),
+                              ),
+                            ),
+                            backgroundColor: WidgetStateProperty.all<Color>(
+                              const Color.fromARGB(255, 245, 241, 248),
+                            ),
+                            side: WidgetStateProperty.all(
+                              const BorderSide(
+                                width: 0.0,
+                                color: Colors.transparent,
+                              ),
+                            ),
                           ),
-                        ),
-                        backgroundColor: WidgetStateProperty.all<Color>(
-                          const Color.fromARGB(255, 245, 241, 248),
-                        ),
-                        side: WidgetStateProperty.all(
-                          const BorderSide(
-                            width: 0.0,
-                            color: Colors.transparent,
-                          ),
-                        ),
-                      ),
-                      child: Text(
-                        "Reply",
-                        style: TextStyle(color: Colors.grey[700], fontSize: 12),
-                      ),
-                    ),
-                  ),
-                  SizedBox(
-                    width: 126,
-                    child: OutlinedButton(
-                      onPressed: () {},
-                      style: ButtonStyle(
-                        shape: WidgetStateProperty.all(
-                          RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(30.0),
-                          ),
-                        ),
-                        backgroundColor: WidgetStateProperty.all<Color>(
-                          const Color.fromARGB(255, 245, 241, 248),
-                        ),
-                        side: WidgetStateProperty.all(
-                          const BorderSide(
-                            width: 0.0,
-                            color: Colors.transparent,
+                          child: Text(
+                            "Reply",
+                            style: TextStyle(
+                              color: Colors.grey[700],
+                              fontSize: 12,
+                            ),
                           ),
                         ),
                       ),
-                      child: Text(
-                        "Reply all",
-                        style: TextStyle(color: Colors.grey[700], fontSize: 12),
+                      SizedBox(
+                        width: stackActions
+                            ? constraints.maxWidth
+                            : (constraints.maxWidth - 8) / 2,
+                        child: OutlinedButton(
+                          onPressed: () {},
+                          style: ButtonStyle(
+                            shape: WidgetStateProperty.all(
+                              RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(30.0),
+                              ),
+                            ),
+                            backgroundColor: WidgetStateProperty.all<Color>(
+                              const Color.fromARGB(255, 245, 241, 248),
+                            ),
+                            side: WidgetStateProperty.all(
+                              const BorderSide(
+                                width: 0.0,
+                                color: Colors.transparent,
+                              ),
+                            ),
+                          ),
+                          child: Text(
+                            "Reply all",
+                            style: TextStyle(
+                              color: Colors.grey[700],
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
                       ),
-                    ),
-                  ),
-                ],
+                    ],
+                  );
+                },
               ),
             ],
           ),

--- a/lib/navigation_bar_theme.dart
+++ b/lib/navigation_bar_theme.dart
@@ -78,6 +78,7 @@ class NavigationBarThemeData
     this.tooltipTrigger,
     this.tooltipTriggerWhenLabelHidden,
     this.tooltipTriggerWhenLabelVisible,
+    this.badgeThemeData,
   });
 
   /// Overrides the default value of [NavigationBar.height].
@@ -200,6 +201,15 @@ class NavigationBarThemeData
   @override
   final EdgeInsetsGeometry? labelPadding;
 
+  /// The theme applied to badges on [NavigationBar] destinations.
+  ///
+  /// Use this to customise badge colors, text style, and size at the
+  /// navigation-bar level without affecting badges elsewhere in the app.
+  ///
+  /// When null, the ambient [BadgeTheme] (if any) or Flutter's default
+  /// [BadgeThemeData] is used.
+  final BadgeThemeData? badgeThemeData;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   @override
@@ -224,6 +234,7 @@ class NavigationBarThemeData
     TooltipTriggerMode? tooltipTrigger,
     TooltipTriggerMode? tooltipTriggerWhenLabelVisible,
     TooltipTriggerMode? tooltipTriggerWhenLabelHidden,
+    BadgeThemeData? badgeThemeData,
   }) {
     return NavigationBarThemeData(
       height: height ?? this.height,
@@ -250,6 +261,7 @@ class NavigationBarThemeData
           tooltipTriggerWhenLabelVisible ?? this.tooltipTriggerWhenLabelVisible,
       tooltipTriggerWhenLabelHidden:
           tooltipTriggerWhenLabelHidden ?? this.tooltipTriggerWhenLabelHidden,
+      badgeThemeData: badgeThemeData ?? this.badgeThemeData,
     );
   }
 
@@ -319,6 +331,8 @@ class NavigationBarThemeData
       tooltipTriggerWhenLabelHidden: t < 0.5
           ? a?.tooltipTriggerWhenLabelHidden
           : b?.tooltipTriggerWhenLabelHidden,
+      badgeThemeData:
+          BadgeThemeData.lerp(a?.badgeThemeData, b?.badgeThemeData, t),
     );
   }
 
@@ -344,6 +358,7 @@ class NavigationBarThemeData
         tooltipTrigger,
         tooltipTriggerWhenLabelVisible,
         tooltipTriggerWhenLabelHidden,
+        badgeThemeData,
       ]);
 
   @override
@@ -375,7 +390,8 @@ class NavigationBarThemeData
         other.tooltipTriggerWhenLabelVisible ==
             tooltipTriggerWhenLabelVisible &&
         other.tooltipTriggerWhenLabelHidden == tooltipTriggerWhenLabelHidden &&
-        other.labelPadding == labelPadding;
+        other.labelPadding == labelPadding &&
+        other.badgeThemeData == badgeThemeData;
   }
 
   @override
@@ -496,6 +512,13 @@ class NavigationBarThemeData
         defaultValue: null,
       ),
     );
+    properties.add(
+      DiagnosticsProperty<BadgeThemeData?>(
+        "badgeThemeData",
+        badgeThemeData,
+        defaultValue: null,
+      ),
+    );
   }
 
   factory NavigationBarThemeData.fromMaterial(
@@ -525,6 +548,7 @@ class NavigationBarThemeData
       tooltipTrigger: null,
       tooltipTriggerWhenLabelVisible: null,
       tooltipTriggerWhenLabelHidden: null,
+      badgeThemeData: null,
     );
   }
 }
@@ -636,6 +660,7 @@ class NavigationBarTheme extends InheritedTheme
             explicitTheme.tooltipTriggerWhenLabelVisible,
         tooltipTriggerWhenLabelHidden:
             explicitTheme.tooltipTriggerWhenLabelHidden,
+        badgeThemeData: explicitTheme.badgeThemeData,
       );
     }
 

--- a/lib/navigation_rail_theme.dart
+++ b/lib/navigation_rail_theme.dart
@@ -79,6 +79,7 @@ class NavigationRailThemeData
     this.unselectedIconTheme,
     this.unselectedLabelTextStyle,
     this.useIndicator,
+    this.badgeThemeData,
   });
 
   /// Color to be used for the [NavigationRail]'s background.
@@ -232,6 +233,15 @@ class NavigationRailThemeData
   /// label-hidden state.
   final TooltipTriggerMode? tooltipTriggerWhenLabelHidden;
 
+  /// The theme applied to badges on [NavigationRail] destinations.
+  ///
+  /// Use this to customise badge colors, text style, and size at the
+  /// navigation-rail level without affecting badges elsewhere in the app.
+  ///
+  /// When null, the ambient [BadgeTheme] (if any) or Flutter's default
+  /// [BadgeThemeData] is used.
+  final BadgeThemeData? badgeThemeData;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   @override
@@ -259,6 +269,7 @@ class NavigationRailThemeData
     TooltipTriggerMode? tooltipTriggerWhenLabelVisible,
     TooltipTriggerMode? tooltipTriggerWhenLabelHidden,
     WidgetStateProperty<IconThemeData?>? iconTheme,
+    BadgeThemeData? badgeThemeData,
   }) {
     return NavigationRailThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -291,6 +302,7 @@ class NavigationRailThemeData
       tooltipTriggerWhenLabelHidden:
           tooltipTriggerWhenLabelHidden ?? this.tooltipTriggerWhenLabelHidden,
       iconTheme: iconTheme ?? this.iconTheme,
+      badgeThemeData: badgeThemeData ?? this.badgeThemeData,
     );
   }
 
@@ -368,6 +380,8 @@ class NavigationRailThemeData
         t,
         IconThemeData.lerp,
       ),
+      badgeThemeData:
+          BadgeThemeData.lerp(a?.badgeThemeData, b?.badgeThemeData, t),
     );
   }
 
@@ -396,6 +410,7 @@ class NavigationRailThemeData
         tooltipTriggerWhenLabelVisible,
         tooltipTriggerWhenLabelHidden,
         iconTheme,
+        badgeThemeData,
       ]);
 
   @override
@@ -430,7 +445,8 @@ class NavigationRailThemeData
         other.tooltipTriggerWhenLabelVisible ==
             tooltipTriggerWhenLabelVisible &&
         other.tooltipTriggerWhenLabelHidden == tooltipTriggerWhenLabelHidden &&
-        other.iconTheme == iconTheme;
+        other.iconTheme == iconTheme &&
+        other.badgeThemeData == badgeThemeData;
   }
 
   @override
@@ -599,6 +615,13 @@ class NavigationRailThemeData
         defaultValue: null,
       ),
     );
+    properties.add(
+      DiagnosticsProperty<BadgeThemeData?>(
+        "badgeThemeData",
+        badgeThemeData,
+        defaultValue: null,
+      ),
+    );
   }
 
   factory NavigationRailThemeData.fromMaterial(
@@ -630,6 +653,7 @@ class NavigationRailThemeData
       tooltipTriggerWhenLabelVisible: null,
       tooltipTriggerWhenLabelHidden: null,
       iconTheme: null,
+      badgeThemeData: null,
     );
   }
 }
@@ -735,6 +759,7 @@ class NavigationRailTheme extends InheritedTheme
         tooltipTriggerWhenLabelHidden:
             explicitTheme.tooltipTriggerWhenLabelHidden,
         iconTheme: explicitTheme.iconTheme,
+        badgeThemeData: explicitTheme.badgeThemeData,
       );
     }
 

--- a/lib/src/navigation_bar/destination.dart
+++ b/lib/src/navigation_bar/destination.dart
@@ -163,13 +163,18 @@ class NavigationBarDestination extends NavigationDestination {
               showBadge && badgeStyle == NavigationBadgeStyle.count
                   ? Text(badge! > 99 ? "99+" : "$badge")
                   : null;
-          final Widget badgedIcon = showBadge
-              ? BadgeTheme(
-                  data: navigationBarTheme.badgeThemeData ??
-                      const BadgeThemeData(),
-                  child: Badge(label: badgeLabel, child: data.themedIcon),
-                )
+          final Widget barBadgedIcon = showBadge
+              ? Badge(label: badgeLabel, child: data.themedIcon)
               : data.themedIcon;
+          // Only apply a local BadgeTheme when explicitly configured.
+          // Otherwise, preserve any ambient BadgeTheme from ancestor widgets.
+          final Widget badgedIcon =
+              showBadge && navigationBarTheme.badgeThemeData != null
+                  ? BadgeTheme(
+                      data: navigationBarTheme.badgeThemeData!,
+                      child: barBadgedIcon,
+                    )
+                  : barBadgedIcon;
 
           return Stack(
             alignment: Alignment.center,

--- a/lib/src/navigation_bar/destination.dart
+++ b/lib/src/navigation_bar/destination.dart
@@ -60,6 +60,8 @@ class NavigationBarDestination extends NavigationDestination {
     super.padding,
     super.enabled,
     super.tooltip,
+    super.badge,
+    super.badgeStyle,
   });
 
   @override
@@ -154,6 +156,21 @@ class NavigationBarDestination extends NavigationDestination {
             ),
           );
 
+          // --- Badge ---
+          final bool showBadge =
+              badge != null && badgeStyle != NavigationBadgeStyle.hidden;
+          final Widget? badgeLabel =
+              showBadge && badgeStyle == NavigationBadgeStyle.count
+                  ? Text(badge! > 99 ? "99+" : "$badge")
+                  : null;
+          final Widget badgedIcon = showBadge
+              ? BadgeTheme(
+                  data: navigationBarTheme.badgeThemeData ??
+                      const BadgeThemeData(),
+                  child: Badge(label: badgeLabel, child: data.themedIcon),
+                )
+              : data.themedIcon;
+
           return Stack(
             alignment: Alignment.center,
             children: <Widget>[
@@ -175,7 +192,7 @@ class NavigationBarDestination extends NavigationDestination {
                       "bar-ink-icon-${destinationInfo.index}-${selectedForKey ? "selected" : "unselected"}",
                     ),
                     child: NavigationIcon(
-                      icon: data.themedIcon,
+                      icon: badgedIcon,
                       minWidth: data.minWidth,
                       material3: data.material3,
                       height: effectiveIndicatorHeight,

--- a/lib/src/navigation_destination.dart
+++ b/lib/src/navigation_destination.dart
@@ -3,6 +3,31 @@ import "navigation_bar/destination.dart";
 import "navigation_rail/destination.dart";
 import "navigation_rail/navigation_rail.dart";
 
+/// Controls how a badge is displayed on a [NavigationDestination] icon.
+///
+/// See also:
+///
+///  * [NavigationDestination.badge], which is the numeric count the badge
+///    represents.
+///  * [NavigationDestination.badgeStyle], which uses this enum.
+enum NavigationBadgeStyle {
+  /// Displays the numeric [NavigationDestination.badge] value as a label.
+  ///
+  /// Values greater than 99 are capped and shown as `"99+"`.
+  count,
+
+  /// Displays a small dot indicator regardless of the numeric value.
+  dot,
+
+  /// Suppresses the badge entirely, even when [NavigationDestination.badge]
+  /// is non-null.
+  ///
+  /// This is useful when you want to retain the badge count in widget state
+  /// without showing a visual indicator — for example, while an in-app
+  /// notification banner is already visible.
+  hidden,
+}
+
 /// A typedef alias for [NavigationDestination].
 ///
 /// Use this name when you need to import both this package and
@@ -73,9 +98,15 @@ class NavigationDestination extends StatelessWidget {
     this.indicatorShape,
     this.margin,
     this.padding,
+    this.badge,
+    this.badgeStyle = NavigationBadgeStyle.count,
     this.enabled = true,
     this.tooltip,
-  })  : selectedIcon = selectedIcon ?? icon,
+  })  : assert(
+          badge == null || badge > 0,
+          "NavigationDestination.badge must be a positive integer.",
+        ),
+        selectedIcon = selectedIcon ?? icon,
         _labelText = label;
 
   /// Indicates that this destination is selectable.
@@ -131,6 +162,28 @@ class NavigationDestination extends StatelessWidget {
     return tooltip!.isNotEmpty ? tooltip : null;
   }
 
+  /// An optional badge count displayed on the destination icon.
+  ///
+  /// When non-null, a badge is rendered over the top-right corner of the icon.
+  /// The visual appearance is controlled by [badgeStyle]:
+  ///
+  ///  * A value of `1`–`99` renders as its string equivalent (e.g. `"3"`).
+  ///  * A value greater than `99` renders as `"99+"`.
+  ///  * Set [badgeStyle] to [NavigationBadgeStyle.dot] to show a small dot
+  ///    regardless of the count.
+  ///  * Set [badgeStyle] to [NavigationBadgeStyle.hidden] to suppress the
+  ///    badge visual while retaining the count value.
+  ///
+  /// Must be `null` or a positive integer (> 0). Defaults to `null`.
+  final int? badge;
+
+  /// Controls the visual presentation of [badge].
+  ///
+  /// Defaults to [NavigationBadgeStyle.count].
+  ///
+  /// Has no effect when [badge] is null.
+  final NavigationBadgeStyle badgeStyle;
+
   /// The color of the selection indicator shown behind the icon.
   ///
   /// If null, [NavigationBarThemeData.indicatorColor] or
@@ -184,6 +237,8 @@ class NavigationDestination extends StatelessWidget {
       padding: padding,
       disabled: !enabled,
       tooltip: railTooltip,
+      badge: badge,
+      badgeStyle: badgeStyle,
     );
   }
 
@@ -206,6 +261,8 @@ class NavigationDestination extends StatelessWidget {
       enabled: enabled,
       // Forward raw tooltip so explicit empty-string suppression is preserved.
       tooltip: tooltip,
+      badge: badge,
+      badgeStyle: badgeStyle,
     );
   }
 

--- a/lib/src/navigation_rail/destination.dart
+++ b/lib/src/navigation_rail/destination.dart
@@ -42,6 +42,8 @@ class NavigationRailDestination extends NavigationDestination {
     super.padding,
     this.disabled = false,
     super.tooltip,
+    super.badge,
+    super.badgeStyle,
   }) : _label = label;
 
   final Widget _label;

--- a/lib/src/navigation_rail/destination_widgets/destination_widget.dart
+++ b/lib/src/navigation_rail/destination_widgets/destination_widget.dart
@@ -199,8 +199,8 @@ class _RailDestinationState extends State<RailDestination>
     Offset indicatorOffset = data.indicatorOffset;
 
     // --- Badge ---
-    final bool showBadge =
-        widget.badge != null && widget.badgeStyle != NavigationBadgeStyle.hidden;
+    final bool showBadge = widget.badge != null &&
+        widget.badgeStyle != NavigationBadgeStyle.hidden;
     final Widget? badgeLabel =
         showBadge && widget.badgeStyle == NavigationBadgeStyle.count
             ? Text(widget.badge! > 99 ? "99+" : "${widget.badge}")

--- a/lib/src/navigation_rail/destination_widgets/destination_widget.dart
+++ b/lib/src/navigation_rail/destination_widgets/destination_widget.dart
@@ -205,12 +205,15 @@ class _RailDestinationState extends State<RailDestination>
         showBadge && widget.badgeStyle == NavigationBadgeStyle.count
             ? Text(widget.badge! > 99 ? "99+" : "${widget.badge}")
             : null;
-    final Widget effectiveBadgedIcon = showBadge
-        ? BadgeTheme(
-            data: railTheme.badgeThemeData ?? const BadgeThemeData(),
-            child: Badge(label: badgeLabel, child: data.themedIcon),
-          )
+    final Widget badgedIcon = showBadge
+        ? Badge(label: badgeLabel, child: data.themedIcon)
         : data.themedIcon;
+    // Only inject a local BadgeTheme when explicitly configured on the rail.
+    // Otherwise, preserve any ambient BadgeTheme from above in the tree.
+    final Widget effectiveBadgedIcon =
+        showBadge && railTheme.badgeThemeData != null
+            ? BadgeTheme(data: railTheme.badgeThemeData!, child: badgedIcon)
+            : badgedIcon;
 
     bool applyXOffset = false;
 

--- a/lib/src/navigation_rail/destination_widgets/destination_widget.dart
+++ b/lib/src/navigation_rail/destination_widgets/destination_widget.dart
@@ -37,6 +37,8 @@ class RailDestination extends StatefulWidget {
     this.padding,
     this.margin,
     this.tooltip,
+    this.badge,
+    this.badgeStyle = NavigationBadgeStyle.count,
     super.key,
   });
 
@@ -61,6 +63,8 @@ class RailDestination extends StatefulWidget {
   final EdgeInsetsGeometry? padding;
   final EdgeInsetsGeometry? margin;
   final String? tooltip;
+  final int? badge;
+  final NavigationBadgeStyle badgeStyle;
 
   @override
   State<RailDestination> createState() => _RailDestinationState();
@@ -194,6 +198,20 @@ class _RailDestinationState extends State<RailDestination>
 
     Offset indicatorOffset = data.indicatorOffset;
 
+    // --- Badge ---
+    final bool showBadge =
+        widget.badge != null && widget.badgeStyle != NavigationBadgeStyle.hidden;
+    final Widget? badgeLabel =
+        showBadge && widget.badgeStyle == NavigationBadgeStyle.count
+            ? Text(widget.badge! > 99 ? "99+" : "${widget.badge}")
+            : null;
+    final Widget effectiveBadgedIcon = showBadge
+        ? BadgeTheme(
+            data: railTheme.badgeThemeData ?? const BadgeThemeData(),
+            child: Badge(label: badgeLabel, child: data.themedIcon),
+          )
+        : data.themedIcon;
+
     bool applyXOffset = false;
 
     Widget content;
@@ -216,7 +234,7 @@ class _RailDestinationState extends State<RailDestination>
         final Widget iconPart = NavigationIcon(
           height: (data.material3 ? _kRailIconSlotHeight : data.minWidth) +
               largeIconIndicatorCompensation,
-          icon: data.themedIcon,
+          icon: effectiveBadgedIcon,
           minWidth: data.minWidth,
           material3: data.material3,
           direction: Axis.horizontal,
@@ -261,7 +279,7 @@ class _RailDestinationState extends State<RailDestination>
                   ),
                   SizedBox(
                     height: _kIndicatorHeight + largeIconIndicatorCompensation,
-                    child: Center(child: data.themedIcon),
+                    child: Center(child: effectiveBadgedIcon),
                   ),
                   SizedBox(
                     height: data.material3 ? _verticalIconLabelSpacingM3 : 0,
@@ -392,9 +410,9 @@ class _RailDestinationState extends State<RailDestination>
                     ? SizedBox(
                         height:
                             _kIndicatorHeight + largeIconIndicatorCompensation,
-                        child: Center(child: data.themedIcon),
+                        child: Center(child: effectiveBadgedIcon),
                       )
-                    : data.themedIcon,
+                    : effectiveBadgedIcon,
                 SizedBox(
                   height: data.material3
                       ? lerpDouble(
@@ -468,9 +486,9 @@ class _RailDestinationState extends State<RailDestination>
                   ? SizedBox(
                       height:
                           _kIndicatorHeight + largeIconIndicatorCompensation,
-                      child: Center(child: data.themedIcon),
+                      child: Center(child: effectiveBadgedIcon),
                     )
-                  : data.themedIcon,
+                  : effectiveBadgedIcon,
               SizedBox(
                 height: data.material3 ? _verticalIconLabelSpacingM3 : 0,
               ),

--- a/lib/src/navigation_rail/navigation_rail.dart
+++ b/lib/src/navigation_rail/navigation_rail.dart
@@ -564,6 +564,8 @@ class _NavigationRailState extends State<NavigationRail>
               disabled: !widget.destinations[i].enabled,
               showLabelsWhenCollapsed: showLabelsWhenCollapsed,
               tooltip: widget.destinations[i].tooltipLabel,
+              badge: widget.destinations[i].badge,
+              badgeStyle: widget.destinations[i].badgeStyle,
             ),
           ),
         if (trailing != null && !widget.trailingAtBottom) trailing,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: custom_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 5.1.0
+version: 5.2.0
 issue_tracker: https://github.com/hanskokx/custom_adaptive_scaffold/issues
 repository: https://github.com/hanskokx/custom_adaptive_scaffold
 

--- a/test/navigation_destination_test.dart
+++ b/test/navigation_destination_test.dart
@@ -19,6 +19,7 @@ import "package:flutter/material.dart"
         NavigationDestination,
         NavigationRailDestination,
         NavigationRail,
+        NavigationRailTheme,
         NavigationRailThemeData,
         NavigationBarThemeData;
 import "package:flutter_test/flutter_test.dart";
@@ -1053,5 +1054,618 @@ void main() {
         );
       },
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Badge
+  // ---------------------------------------------------------------------------
+
+  group("NavigationDestination badge", () {
+    // --- Assertion ---
+
+    test("badge: 0 throws AssertionError", () {
+      expect(
+        () => NavigationDestination(
+          icon: const Icon(Icons.home),
+          label: "Home",
+          badge: 0,
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test("badge: -1 throws AssertionError", () {
+      expect(
+        () => NavigationDestination(
+          icon: const Icon(Icons.home),
+          label: "Home",
+          badge: -1,
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test("badge: null does not throw", () {
+      expect(
+        () => const NavigationDestination(
+          icon: Icon(Icons.home),
+          label: "Home",
+        ),
+        returnsNormally,
+      );
+    });
+
+    // --- Conversion: toRailDestination ---
+
+    test("toRailDestination forwards badge value", () {
+      const dest = NavigationDestination(
+        icon: Icon(Icons.home),
+        label: "Home",
+        badge: 5,
+      );
+      expect(dest.toRailDestination().badge, 5);
+    });
+
+    test("toRailDestination forwards badgeStyle: dot", () {
+      const dest = NavigationDestination(
+        icon: Icon(Icons.home),
+        label: "Home",
+        badge: 3,
+        badgeStyle: NavigationBadgeStyle.dot,
+      );
+      expect(dest.toRailDestination().badgeStyle, NavigationBadgeStyle.dot);
+    });
+
+    test("toRailDestination forwards badgeStyle: hidden", () {
+      const dest = NavigationDestination(
+        icon: Icon(Icons.home),
+        label: "Home",
+        badge: 3,
+        badgeStyle: NavigationBadgeStyle.hidden,
+      );
+      expect(dest.toRailDestination().badgeStyle, NavigationBadgeStyle.hidden);
+    });
+
+    test(
+        "toRailDestination preserves badge on NavigationRailDestination passthrough",
+        () {
+      // When the destination is already a NavigationRailDestination the
+      // early-return guard must not lose the badge.
+      const original = NavigationRailDestination(
+        icon: Icon(Icons.home),
+        label: Text("Home"),
+        badge: 42,
+        badgeStyle: NavigationBadgeStyle.dot,
+      );
+      final result = original.toRailDestination();
+      expect(result.badge, 42);
+      expect(result.badgeStyle, NavigationBadgeStyle.dot);
+    });
+
+    test("badgeStyle defaults to count", () {
+      const dest = NavigationDestination(
+        icon: Icon(Icons.home),
+        label: "Home",
+        badge: 1,
+      );
+      expect(dest.badgeStyle, NavigationBadgeStyle.count);
+      expect(dest.toRailDestination().badgeStyle, NavigationBadgeStyle.count);
+      expect(dest.toBarDestination().badgeStyle, NavigationBadgeStyle.count);
+    });
+
+    // --- Conversion: toBarDestination ---
+
+    test("toBarDestination forwards badge value", () {
+      const dest = NavigationDestination(
+        icon: Icon(Icons.home),
+        label: "Home",
+        badge: 7,
+      );
+      expect(dest.toBarDestination().badge, 7);
+    });
+
+    test("toBarDestination forwards badgeStyle: dot", () {
+      const dest = NavigationDestination(
+        icon: Icon(Icons.home),
+        label: "Home",
+        badge: 3,
+        badgeStyle: NavigationBadgeStyle.dot,
+      );
+      expect(dest.toBarDestination().badgeStyle, NavigationBadgeStyle.dot);
+    });
+
+    // --- Rail rendering ---
+
+    testWidgets("badge: null renders no Badge widget in rail",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsNothing);
+    });
+
+    testWidgets("badge: 5 renders Badge with label '5' in rail",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 5,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsOneWidget);
+      expect(find.text("5"), findsOneWidget);
+    });
+
+    testWidgets("badge: 99 renders '99' (boundary — not capped) in rail",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 99,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.text("99"), findsOneWidget);
+      expect(find.text("99+"), findsNothing);
+    });
+
+    testWidgets("badge: 100 renders '99+' (cap) in rail",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 100,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.text("99+"), findsOneWidget);
+    });
+
+    testWidgets("badge: 150 renders '99+' in rail",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 150,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.text("99+"), findsOneWidget);
+    });
+
+    testWidgets("badgeStyle: dot renders Badge without label in rail",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 3,
+              badgeStyle: NavigationBadgeStyle.dot,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsOneWidget);
+      expect(find.text("3"), findsNothing);
+    });
+
+    testWidgets("badgeStyle: hidden suppresses Badge in rail",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 3,
+              badgeStyle: NavigationBadgeStyle.hidden,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsNothing);
+    });
+
+    testWidgets("badge renders in extended rail (labelType.none, extended)",
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await pumpApp(
+        tester,
+        Row(
+          children: [
+            NavigationRail(
+              selectedIndex: 0,
+              extended: true,
+              destinations: [
+                const NavigationDestination(
+                  icon: Icon(Icons.home),
+                  label: "Home",
+                  badge: 5,
+                ).toRailDestination(),
+                const NavigationDestination(
+                  icon: Icon(Icons.search),
+                  label: "Search",
+                ).toRailDestination(),
+              ],
+            ),
+            const Expanded(child: SizedBox()),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(Badge), findsOneWidget);
+      expect(find.text("5"), findsOneWidget);
+    });
+
+    testWidgets("badge renders in rail with labelType.all",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          labelType: NavigationRailLabelType.all,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 5,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsOneWidget);
+      expect(find.text("5"), findsOneWidget);
+    });
+
+    testWidgets("badge renders in rail with labelType.selected",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationRail(
+          selectedIndex: 0,
+          labelType: NavigationRailLabelType.selected,
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 5,
+            ).toRailDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toRailDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsOneWidget);
+    });
+
+    testWidgets(
+        "NavigationRailThemeData.badgeThemeData wraps badge with BadgeTheme",
+        (WidgetTester tester) async {
+      const Color badgeColor = Color(0xFF0000FF);
+      await pumpApp(
+        tester,
+        NavigationRailTheme(
+          data: const NavigationRailThemeData(
+            badgeThemeData: BadgeThemeData(backgroundColor: badgeColor),
+          ),
+          child: NavigationRail(
+            selectedIndex: 0,
+            destinations: [
+              const NavigationDestination(
+                icon: Icon(Icons.home),
+                label: "Home",
+                badge: 1,
+              ).toRailDestination(),
+              const NavigationDestination(
+                icon: Icon(Icons.search),
+                label: "Search",
+              ).toRailDestination(),
+            ],
+          ),
+        ),
+      );
+      expect(
+        find.byWidgetPredicate(
+          (Widget w) => w is BadgeTheme && w.data.backgroundColor == badgeColor,
+        ),
+        findsOneWidget,
+      );
+    });
+
+    // --- Bar rendering ---
+
+    testWidgets("badge: null renders no Badge widget in bar",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: const [
+            NavigationBarDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+            ),
+            NavigationBarDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsNothing);
+    });
+
+    testWidgets("badge: 5 renders Badge with label '5' in bar",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 5,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toBarDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsOneWidget);
+      expect(find.text("5"), findsOneWidget);
+    });
+
+    testWidgets("badge: 99 renders '99' (boundary — not capped) in bar",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 99,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toBarDestination(),
+          ],
+        ),
+      );
+      expect(find.text("99"), findsOneWidget);
+      expect(find.text("99+"), findsNothing);
+    });
+
+    testWidgets("badge: 100 renders '99+' (cap) in bar",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 100,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toBarDestination(),
+          ],
+        ),
+      );
+      expect(find.text("99+"), findsOneWidget);
+    });
+
+    testWidgets("badge: 150 renders '99+' in bar", (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 150,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toBarDestination(),
+          ],
+        ),
+      );
+      expect(find.text("99+"), findsOneWidget);
+    });
+
+    testWidgets("badgeStyle: dot renders Badge without label in bar",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 3,
+              badgeStyle: NavigationBadgeStyle.dot,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toBarDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsOneWidget);
+      expect(find.text("3"), findsNothing);
+    });
+
+    testWidgets("badgeStyle: hidden suppresses Badge in bar",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 3,
+              badgeStyle: NavigationBadgeStyle.hidden,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+            ).toBarDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsNothing);
+    });
+
+    testWidgets(
+        "NavigationBarThemeData.badgeThemeData wraps badge with BadgeTheme",
+        (WidgetTester tester) async {
+      const Color badgeColor = Color(0xFFFF0000);
+      await pumpApp(
+        tester,
+        NavigationBarTheme(
+          data: const NavigationBarThemeData(
+            badgeThemeData: BadgeThemeData(backgroundColor: badgeColor),
+          ),
+          child: NavigationBar(
+            destinations: [
+              const NavigationDestination(
+                icon: Icon(Icons.home),
+                label: "Home",
+                badge: 1,
+              ).toBarDestination(),
+              const NavigationDestination(
+                icon: Icon(Icons.search),
+                label: "Search",
+              ).toBarDestination(),
+            ],
+          ),
+        ),
+      );
+      expect(
+        find.byWidgetPredicate(
+          (Widget w) => w is BadgeTheme && w.data.backgroundColor == badgeColor,
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets("multiple destinations each render their own badge in bar",
+        (WidgetTester tester) async {
+      await pumpApp(
+        tester,
+        NavigationBar(
+          destinations: [
+            const NavigationDestination(
+              icon: Icon(Icons.home),
+              label: "Home",
+              badge: 150,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.search),
+              label: "Search",
+              badge: 1,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.settings),
+              label: "Settings",
+              badge: 1,
+              badgeStyle: NavigationBadgeStyle.dot,
+            ).toBarDestination(),
+            const NavigationDestination(
+              icon: Icon(Icons.person),
+              label: "Profile",
+            ).toBarDestination(),
+          ],
+        ),
+      );
+      expect(find.byType(Badge), findsNWidgets(3));
+      expect(find.text("99+"), findsOneWidget);
+      expect(find.text("1"), findsOneWidget);
+    });
   });
 }

--- a/test/navigation_destination_test.dart
+++ b/test/navigation_destination_test.dart
@@ -1449,6 +1449,41 @@ void main() {
       );
     });
 
+    testWidgets(
+        "NavigationRailThemeData.badgeThemeData null preserves ambient BadgeTheme",
+        (WidgetTester tester) async {
+      const Color ambientBadgeColor = Color(0xFF00FF00);
+      await pumpApp(
+        tester,
+        BadgeTheme(
+          data: const BadgeThemeData(backgroundColor: ambientBadgeColor),
+          child: NavigationRailTheme(
+            data: const NavigationRailThemeData(
+              badgeThemeData: null,
+            ),
+            child: NavigationRail(
+              selectedIndex: 0,
+              destinations: [
+                const NavigationDestination(
+                  icon: Icon(Icons.home),
+                  label: "Home",
+                  badge: 1,
+                ).toRailDestination(),
+                const NavigationDestination(
+                  icon: Icon(Icons.search),
+                  label: "Search",
+                ).toRailDestination(),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final Badge badge = tester.widget<Badge>(find.byType(Badge));
+      final BuildContext badgeContext = tester.element(find.byWidget(badge));
+      expect(BadgeTheme.of(badgeContext).backgroundColor, ambientBadgeColor);
+    });
+
     // --- Bar rendering ---
 
     testWidgets("badge: null renders no Badge widget in bar",
@@ -1632,6 +1667,40 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets(
+        "NavigationBarThemeData.badgeThemeData null preserves ambient BadgeTheme",
+        (WidgetTester tester) async {
+      const Color ambientBadgeColor = Color(0xFF00AA00);
+      await pumpApp(
+        tester,
+        BadgeTheme(
+          data: const BadgeThemeData(backgroundColor: ambientBadgeColor),
+          child: NavigationBarTheme(
+            data: const NavigationBarThemeData(
+              badgeThemeData: null,
+            ),
+            child: NavigationBar(
+              destinations: [
+                const NavigationDestination(
+                  icon: Icon(Icons.home),
+                  label: "Home",
+                  badge: 1,
+                ).toBarDestination(),
+                const NavigationDestination(
+                  icon: Icon(Icons.search),
+                  label: "Search",
+                ).toBarDestination(),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final Badge badge = tester.widget<Badge>(find.byType(Badge));
+      final BuildContext badgeContext = tester.element(find.byWidget(badge));
+      expect(BadgeTheme.of(badgeContext).backgroundColor, ambientBadgeColor);
     });
 
     testWidgets("multiple destinations each render their own badge in bar",


### PR DESCRIPTION
### Summary

Implements the [M3 badge spec](https://m3.material.io/components/navigation-rail/guidelines#b51e4558-351f-4368-af8d-bbf1f63f68b4) for navigation destinations across both `NavigationBar` and `NavigationRail`.

---

### What's new

**`NavigationDestination.badge` (`int?`)**
Set a positive integer to show a badge on the destination icon. Values over `99` are automatically displayed as `"99+"`. Passing `null` (the default) shows no badge — the default path adds no `Badge` widget to the tree, so all existing framework-mirror tests pass without modification.

**`NavigationDestination.badgeStyle` (`NavigationBadgeStyle`)**
An enum that controls the visual presentation:

| Value | Behavior |
|---|---|
| `count` | Shows the numeric value; `> 99` → `"99+"` (default) |
| `dot` | Shows a small dot indicator regardless of value |
| `hidden` | Suppresses the badge visually while retaining the count in the widget tree |

**`NavigationRailThemeData.badgeThemeData` / `NavigationBarThemeData.badgeThemeData` (`BadgeThemeData?`)**
Theme-level badge styling (color, text style, size, alignment) scoped to each navigation surface independently.

---

### Implementation notes

- Rendering delegates to Flutter's `Badge` widget wrapping the destination icon, so M3-spec positioning and RTL support come for free.
- `badge` and `badgeStyle` are forwarded through `toRailDestination()` and `toBarDestination()`, including through the `is NavigationRailDestination` passthrough guard.
- `assert(badge == null || badge > 0)` fires in debug mode for zero/negative values.

---

### Tests

30 new tests added to navigation_destination_test.dart under the `"NavigationDestination badge"` group:

- Assertion errors for `badge: 0` and `badge: -1`
- `toRailDestination()` / `toBarDestination()` forward `badge` and `badgeStyle` (including passthrough guard)
- `badgeStyle` defaults to `count`
- Rail: `null`, labeled counts (`5`, `99` boundary, `100`/`150` cap), `dot`, `hidden`, collapsed/extended/`labelType.all`/`labelType.selected`
- Bar: same count/cap/dot/hidden matrix, multiple badged destinations in one bar
- `badgeThemeData` applied via `NavigationRailTheme` and `NavigationBarTheme`

All 395 tests pass.